### PR TITLE
Add back to tenant selection page

### DIFF
--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -41,13 +41,13 @@
 
                 <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
                     <div id="kc-form-options">
-                    <#if realm.resetPasswordAllowed>
-                        <span><a tabindex="5" href="${client.baseUrl}/forgot-password">${msg("doForgotPassword")}</a></span>
+                        <#if realm.resetPasswordAllowed>
+                            <span><a tabindex="5" href="${client.baseUrl}/forgot-password">${msg("doForgotPassword")}</a></span>
                         </#if>
-                        </div>
-                        <div class="${properties.kcFormOptionsWrapperClass!}">
-                                <span><a tabindex="6" href="${client.baseUrl}/forgot-username">${msg("doForgotUsername")}</a></span>
-                        </div>
+                    </div>
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span><a tabindex="6" href="${client.baseUrl}/forgot-username">${msg("doForgotUsername")}</a></span>
+                    </div>
 
                   </div>
 
@@ -55,6 +55,8 @@
                       <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                       <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
+
+                  <a href="${client.baseUrl}" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
             </form>
         </#if>
         </div>

--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -55,8 +55,15 @@
                       <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                       <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
+                  <a href="${client.baseUrl}" id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
+                  <script type="text/javascript">
+                      const urlParams = new URLSearchParams(window.location.search);
+                      const isConsortium = urlParams.get('isConsortium');
 
-                  <a href="${client.baseUrl}" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
+                      if (isConsortium === 'true') {
+                          document.getElementById('return-to-tenant-selection').style.display = 'block';
+                      }
+                  </script>
             </form>
         </#if>
         </div>

--- a/custom-theme/login/messages/messages_en.properties
+++ b/custom-theme/login/messages/messages_en.properties
@@ -168,6 +168,7 @@ emailLinkIdp4=If you already verified the email in different browser
 emailLinkIdp5=to continue.
 
 backToLogin=&laquo; Back to Login
+backToTenantSelection=Return to tenant/library selection screen
 
 emailInstruction=Enter your username or email address and we will send you instructions on how to create a new password.
 emailInstructionUsername=Enter your username and we will send you instructions on how to create a new password.

--- a/custom-theme/login/resources/css/login.css
+++ b/custom-theme/login/resources/css/login.css
@@ -94,3 +94,10 @@ input:focus {
     height: 60px;
     background-color: #1960a4 !important;
 }
+
+.return-to-tenant-selection {
+  display: block;
+  text-align: center;
+  font-weight: bold;
+  font-size: 1rem;
+}

--- a/custom-theme/login/resources/css/login.css
+++ b/custom-theme/login/resources/css/login.css
@@ -96,7 +96,6 @@ input:focus {
 }
 
 .return-to-tenant-selection {
-  display: block;
   text-align: center;
   font-weight: bold;
   font-size: 1rem;

--- a/custom-theme/login/theme.properties
+++ b/custom-theme/login/theme.properties
@@ -79,6 +79,7 @@ kcFormOptionsClass=col-xs-12 col-sm-12 col-md-12 col-lg-12
 kcFormButtonsClass=col-xs-12 col-sm-12 col-md-12 col-lg-12
 kcFormSettingClass=login-pf-settings
 kcTextareaClass=form-control
+kcReturnToTenantSelection=return-to-tenant-selection
 kcSignUpClass=login-pf-signup
 
 


### PR DESCRIPTION
Login screen when navigating from Tenant Selection screen:

<img width="1443" alt="image" src="https://github.com/folio-org/folio-keycloak/assets/28395235/732411a1-c807-42b7-85c6-9b4f78cdc052">

Login screen when Tenant Selection is disabled (no back link):

<img width="1352" alt="image" src="https://github.com/folio-org/folio-keycloak/assets/28395235/56a58be7-ce6c-44fb-9931-bb1e8b26ba88">

