### PR TITLE
Adjusted imported styles and override order so correct default font size of 12px is used

### DIFF
--- a/custom-theme/login/theme.properties
+++ b/custom-theme/login/theme.properties
@@ -1,9 +1,8 @@
 parent=keycloak
-styles=css/login.css
 
 meta=viewport==width=device-width,initial-scale=1
 
-stylesCommon=web_modules/@patternfly/react-core/dist/styles/base.css web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/pficon/pficon.css
+styles=node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/pficon/pficon.css css/login.css
 
 meta=viewport==width=device-width,initial-scale=1
 


### PR DESCRIPTION
Following the guidance in keycloak documentation: https://www.keycloak.org/docs/22.0.3/server_development/#add-a-stylesheet-to-a-theme

Styles in this field apply sequentially, so the last listed style (our-own) gets the final override. In testing in EVRK, I also determined that `base.css` and `app.css` are not necessary. 

Working screenshot from EVRK (no console warnings/errors):

<img width="1302" alt="image" src="https://github.com/folio-org/folio-keycloak/assets/28395235/0f8168c2-adc0-4c3d-8cce-5b095b38d53e">
