### PR TITLE
KEYCLOAK-4 Restore missing Error page which includes back link

### DIFF
--- a/custom-theme/login/error.ftl
+++ b/custom-theme/login/error.ftl
@@ -1,0 +1,16 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "header">
+        ${kcSanitize(msg("errorTitle"))?no_esc}
+    <#elseif section = "form">
+        <div id="kc-error-message">
+            <p class="instruction">${kcSanitize(message.summary)?no_esc}</p>
+            <#if skipLink??>
+            <#else>
+                <#if client?? && client.baseUrl?has_content>
+                    <p><a id="backToApplication" href="${client.baseUrl}">${kcSanitize(msg("backToApplication"))?no_esc}</a></p>
+                </#if>
+            </#if>
+        </div>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
- Fixes [KEYCLOAK-4](https://issues.folio.org/browse/KEYCLOAK-4).
- Previously when trying to navigate with browser back after logging out, user would see 

<img width="1222" alt="Screenshot 2024-01-31 at 3 57 17 PM" src="https://github.com/folio-org/folio-keycloak/assets/28395235/9a734a78-581d-45c9-8096-bcc093050cfc">

Which did not include a link to return to Login screen. I noticed that our custom templates did not reference our error messages defined in our translation files, so I suspected the base template was taking over. I unpacked keycloak-themes.jar and found error.ftl which references our error message. I also saw it has handling for returning to the base application (in our case, the login screen). After bringing error.ftl into our custom templates, we now get the expected back link:

<img width="1219" alt="Screenshot 2024-01-31 at 3 33 18 PM" src="https://github.com/folio-org/folio-keycloak/assets/28395235/ae3daf92-da16-4d4b-9892-77604f910b70">

The code in this PR is copied from base keycloak-themes.jar as may be referenced in https://github.com/keycloak/keycloak/releases/download/23.0.5/keycloak-23.0.5.zip