### PR TITLE
Get external URLs from redirect_uri

### DIFF
--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -42,11 +42,11 @@
                 <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
                     <div id="kc-form-options">
                         <#if realm.resetPasswordAllowed>
-                            <span><a tabindex="5" href="${client.baseUrl}/forgot-password">${msg("doForgotPassword")}</a></span>
+                            <span><a id="forgot-password" tabindex="5">${msg("doForgotPassword")}</a></span>
                         </#if>
                     </div>
                     <div class="${properties.kcFormOptionsWrapperClass!}">
-                        <span><a tabindex="6" href="${client.baseUrl}/forgot-username">${msg("doForgotUsername")}</a></span>
+                        <span><a id="forgot-username" tabindex="6">${msg("doForgotUsername")}</a></span>
                     </div>
 
                   </div>
@@ -55,13 +55,24 @@
                       <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                       <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
-                  <a href="${client.baseUrl}" id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
+                  <a id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
                   <script type="text/javascript">
                       const urlParams = new URLSearchParams(window.location.search);
                       const isConsortium = urlParams.get('isConsortium');
+                      const redirectUri = urlParams.get('redirect_uri');
+                      const baseUrl = redirectUri ? new URL(redirectUri).origin : null;
+                      const returnToTenantSelection = document.getElementById('return-to-tenant-selection');
+                      const forgotUsername = document.getElementById('forgot-username');
+                      const forgotPassword = document.getElementById('forgot-password');
 
-                      if (isConsortium === 'true') {
-                          document.getElementById('return-to-tenant-selection').style.display = 'block';
+                      if (baseUrl) {
+                          if (forgotUsername) forgotUsername.href = baseUrl + '/forgot-username';
+                          if (forgotPassword) forgotPassword.href = baseUrl + '/forgot-password';
+
+                          if (isConsortium === 'true' && returnToTenantSelection) {
+                              returnToTenantSelection.href = baseUrl;
+                              returnToTenantSelection.style.display = 'block';
+                          }
                       }
                   </script>
             </form>


### PR DESCRIPTION
Fixes [KEYCLOAK-5](https://folio-org.atlassian.net/browse/KEYCLOAK-5)

Instead of expecting FOLIO base URL to come from keycloak configuration (which may be undefined), use `redirect_uri` in URL, which Stripes provides and will exist unless there is a future breaking code change. 

Note that keycloak does not support several ES6+ Javascript features, so oldschool syntax was required for template to run. No string interpolation, etc.