### PR TITLE
Implement "back to login" on the "failed to logout" screen

### DIFF
--- a/custom-theme/login/error.ftl
+++ b/custom-theme/login/error.ftl
@@ -1,0 +1,16 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "header">
+        ${kcSanitize(msg("errorTitle"))?no_esc}
+    <#elseif section = "form">
+        <div id="kc-error-message">
+            <p class="instruction">${kcSanitize(message.summary)?no_esc}</p>
+            <#if skipLink??>
+            <#else>
+                <#if client?? && client.baseUrl?has_content>
+                    <p><a id="backToApplication" href="${client.baseUrl}">${kcSanitize(msg("backToApplication"))?no_esc}</a></p>
+                </#if>
+            </#if>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/custom-theme/login/error.ftl
+++ b/custom-theme/login/error.ftl
@@ -5,12 +5,9 @@
     <#elseif section = "form">
         <div id="kc-error-message">
             <p class="instruction">${kcSanitize(message.summary)?no_esc}</p>
-            <#if skipLink??>
-            <#else>
-                <#if client?? && client.baseUrl?has_content>
-                    <p><a id="backToApplication" href="${client.baseUrl}">${kcSanitize(msg("backToApplication"))?no_esc}</a></p>
-                </#if>
-            </#if>
+              <#if client?? && client.baseUrl?has_content>
+                  <p><a id="backToApplication" href="${client.baseUrl}">${kcSanitize(msg("backToApplication"))?no_esc}</a></p>
+              </#if>
         </div>
     </#if>
 </@layout.registrationLayout>

--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -42,11 +42,11 @@
                 <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
                     <div id="kc-form-options">
                         <#if realm.resetPasswordAllowed>
-                            <span><a id="forgot-password" tabindex="5">${msg("doForgotPassword")}</a></span>
+                            <span><a tabindex="5" href="${client.baseUrl}/forgot-password">${msg("doForgotPassword")}</a></span>
                         </#if>
                     </div>
                     <div class="${properties.kcFormOptionsWrapperClass!}">
-                        <span><a id="forgot-username" tabindex="6">${msg("doForgotUsername")}</a></span>
+                        <span><a tabindex="6" href="${client.baseUrl}/forgot-username">${msg("doForgotUsername")}</a></span>
                     </div>
 
                   </div>
@@ -55,24 +55,13 @@
                       <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                       <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
-                  <a id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
+                  <a href="${client.baseUrl}" id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
                   <script type="text/javascript">
                       const urlParams = new URLSearchParams(window.location.search);
                       const isConsortium = urlParams.get('isConsortium');
-                      const redirectUri = urlParams.get('redirect_uri');
-                      const baseUrl = redirectUri ? new URL(redirectUri).origin : null;
-                      const returnToTenantSelection = document.getElementById('return-to-tenant-selection');
-                      const forgotUsername = document.getElementById('forgot-username');
-                      const forgotPassword = document.getElementById('forgot-password');
 
-                      if (baseUrl) {
-                          if (forgotUsername) forgotUsername.href = baseUrl + '/forgot-username';
-                          if (forgotPassword) forgotPassword.href = baseUrl + '/forgot-password';
-
-                          if (isConsortium === 'true' && returnToTenantSelection) {
-                              returnToTenantSelection.href = baseUrl;
-                              returnToTenantSelection.style.display = 'block';
-                          }
+                      if (isConsortium === 'true') {
+                          document.getElementById('return-to-tenant-selection').style.display = 'block';
                       }
                   </script>
             </form>


### PR DESCRIPTION
- Fulfills [KEYCLOAK-4](https://folio-org.atlassian.net/browse/KEYCLOAK-4).
- Removes a condition from the error page that previously hid the "Back to Application" link. We always want this link to display.
- Switching all code to use `client.baseUrl` as the URL parameter `redirect_uri` is not available on the Logout error screen (and is not easily passable through the postback workflow that occurs). 