### PR TITLE
KEYCLOAK-22 omit "Or sign in with" headline in SSO-only template

### DIFF
--- a/custom-theme-sso-only/login/login.ftl
+++ b/custom-theme-sso-only/login/login.ftl
@@ -18,8 +18,6 @@
         <#if realm.password && social.providers??>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
                 <hr/>
-                <h4>${msg("identity-provider-login-label")}</h4>
-
                 <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
                     <#list social.providers as p>
                         <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"


### PR DESCRIPTION
SSO is the _only_ sign-in option in the SSO-only template, making the "Or ..." headline confusing since there are no other sign-in options.

Refs [KEYCLOAK-22](https://folio-org.atlassian.net/browse/KEYCLOAK-22)