### PR TITLE
KEYCLOAK-22 include SSO-only templates in fips image

### DIFF
--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -47,6 +47,7 @@ COPY --chown=keycloak:keycloak folio/configure-realms.sh /opt/keycloak/bin/folio
 COPY --chown=keycloak:keycloak folio/setup-admin-client.sh /opt/keycloak/bin/folio/setup-admin-client.sh
 COPY --chown=keycloak:keycloak folio/start-fips.sh /opt/keycloak/bin/folio/start-fips.sh
 COPY --chown=keycloak:keycloak custom-theme /opt/keycloak/themes/custom-theme
+COPY --chown=keycloak:keycloak custom-theme-sso-only /opt/keycloak/themes/custom-theme-sso-only
 
 USER root
 RUN chmod -R 550 /opt/keycloak/bin/folio


### PR DESCRIPTION
Include the SSO-only templates in Dockerfile-fips, just as they are included in the regular Dockerfile.

Refs [KEYCLOAK-22](https://folio-org.atlassian.net/browse/KEYCLOAK-22)