### PR TITLE
KEYCLOAK-23 Allow log level to be specified via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ docker build -t folio-keycloak .
 
 ### Additional variables for container
 
-| METHOD                          | REQUIRED | DEFAULT VALUE              | DESCRIPTION                 |
-|:--------------------------------|:--------:|:---------------------------|:----------------------------|
-| KC_FOLIO_BE_ADMIN_CLIENT_ID     |  false   | folio-backend-admin-client | Folio backend client id     |
-| KC_FOLIO_BE_ADMIN_CLIENT_SECRET |   true   | -                          | Folio backend client secret |
-| KC_HTTPS_KEY_STORE_PASSWORD     |   true   | -                          | BCFSK Keystore password     |
-| KCADM_HTTPS_TRUST_STORE_PASSWORD|  false   | SecretPassword             | Truststore password         |
+| METHOD                           | REQUIRED | DEFAULT VALUE                                                   | DESCRIPTION                 |
+|:---------------------------------|:--------:|:----------------------------------------------------------------|:----------------------------|
+| KC_FOLIO_BE_ADMIN_CLIENT_ID      |  false   | folio-backend-admin-client                                      | Folio backend client id     |
+| KC_FOLIO_BE_ADMIN_CLIENT_SECRET  |   true   | -                                                               | Folio backend client secret |
+| KC_HTTPS_KEY_STORE_PASSWORD      |   true   | -                                                               | BCFSK Keystore password     |
+| KCADM_HTTPS_TRUST_STORE_PASSWORD |  false   | SecretPassword                                                  | Truststore password         |
+| KC_LOG_LEVEL                     |  false   | INFO,org.keycloak.common.crypto:TRACE,org.keycloak.crypto:TRACE | Keycloak log level          |

--- a/folio/start-fips.sh
+++ b/folio/start-fips.sh
@@ -11,6 +11,7 @@ fi
 
 kcCache=ispn
 kcCacheConfigFile=cache-ispn-jdbc.xml
+logLevel=INFO,org.keycloak.common.crypto:TRACE,org.keycloak.crypto:TRACE
 
 echo "Starting in FIPS mode"
 /opt/keycloak/bin/kc.sh start \
@@ -22,5 +23,5 @@ echo "Starting in FIPS mode"
  --spi-password-hashing-pbkdf2-sha256-max-padding-length=14 \
  --cache="$kcCache" \
  --cache-config-file="$kcCacheConfigFile" \
- --log-level=INFO,org.keycloak.common.crypto:TRACE,org.keycloak.crypto:TRACE \
+ --log-level="${KC_LOG_LEVEL:-${logLevel}}" \
  -Djava.security.properties=/opt/keycloak/conf/java.security

--- a/folio/start.sh
+++ b/folio/start.sh
@@ -11,6 +11,7 @@ fi
 
 kcCache=ispn
 kcCacheConfigFile=cache-ispn-jdbc.xml
+logLevel=INFO,org.keycloak.common.crypto:TRACE,org.keycloak.crypto:TRACE
 
 echo "Starting in non FIPS mode"
 /opt/keycloak/bin/kc.sh start \
@@ -22,4 +23,4 @@ echo "Starting in non FIPS mode"
   --spi-password-hashing-pbkdf2-sha256-max-padding-length=14 \
   --cache="$kcCache" \
   --cache-config-file="$kcCacheConfigFile" \
-  --log-level=INFO,org.keycloak.common.crypto:TRACE,org.keycloak.crypto:TRACE
+  --log-level="${KC_LOG_LEVEL:-${logLevel}}"


### PR DESCRIPTION
## Purpose
Allow log level to be specified via an environment variable so it can be adjusted w/o needing to rebuild a new image.
US: [KEYCLOAK-23](https://folio-org.atlassian.net/browse/KEYCLOAK-23)

## Approach
* introduce `KC_LOG_LEVEL` env variable with default value
* pass the variable to fips/non-fips start up scripts