### PR TITLE
Add BASE_LOGO_FILES_URL environment variable

### DIFF
--- a/custom-theme/login/theme.properties
+++ b/custom-theme/login/theme.properties
@@ -6,7 +6,7 @@ styles=node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternf
 
 meta=viewport==width=device-width,initial-scale=1
 
-baseLogoFilesURL=https://eureka-customer-assets.s3.us-west-2.amazonaws.com
+baseLogoFilesURL=${env.BASE_LOGO_FILES_URL:https://eureka-customer-assets.s3.us-west-2.amazonaws.com}
 
 kcHtmlClass=login-body
 kcLoginClass=login-wrapper


### PR DESCRIPTION
- This adds an environment variable called `BASE_LOGO_FILES_URL` which can be passed in through any build job (such as Jenkins). If no value is provided, the previous value `https://eureka-customer-assets.s3.us-west-2.amazonaws.com` is used as a default.

- Fulfills [KEYCLOAK-8](https://folio-org.atlassian.net/browse/KEYCLOAK-8)