### PR TITLE
KEYCLOAK-29 username, password fields are required

### DIFF
--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -11,8 +11,17 @@
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
 
-                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off"
-                               aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                        <input
+                            tabindex="1"
+                            id="username"
+                            class="${properties.kcInputClass!}"
+                            name="username"
+                            value="${(login.username!'')}"
+                            type="text"
+                            autofocus
+                            autocomplete="off"
+                            aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                            required
                         />
 
                         <#if messagesPerField.existsError('username','password')>
@@ -27,8 +36,15 @@
                 <div class="${properties.kcFormGroupClass!}">
                     <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
 
-                    <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off"
-                           aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                    <input
+                        tabindex="2"
+                        id="password"
+                        class="${properties.kcInputClass!}"
+                        name="password"
+                        type="password"
+                        autocomplete="off"
+                        aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                        required
                     />
 
                     <#if usernameHidden?? && messagesPerField.existsError('username','password')>


### PR DESCRIPTION
Add `required` attribute to `username` and `password` fields so they show the browser's built-in "Please fill out this field" warning if the user clicks the "Sign In" button when either field is empty.

Refs [KEYCLOACK-29](https://folio-org.atlassian.net/browse/KEYCLOAK-29)

### before
<img width="1440" alt="before" src="https://github.com/user-attachments/assets/6d92bc67-fcf0-4612-be55-e06cff18ec6c">

### after
<img width="1440" alt="after" src="https://github.com/user-attachments/assets/edfae38e-af75-4ab5-8ebf-08dda7f437a4">
