### PR TITLE
KEYCLOAK-33: Upgrade keycloak from 25 to 26 fixing vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.20.1
-ARG KEYCLOAK_VERSION=25.0.6
+ARG KEYCLOAK_VERSION=26.0.7
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.20.1
-ARG KEYCLOAK_VERSION=26.0.7
+ARG KEYCLOAK_VERSION=26.0.8
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.20.1
-ARG KEYCLOAK_VERSION=25.0.6
+ARG KEYCLOAK_VERSION=26.0.7
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.20.1
-ARG KEYCLOAK_VERSION=26.0.7
+ARG KEYCLOAK_VERSION=26.0.8
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/SECURITY-231

Upgrade keycloak from 25.0.6 to 26.0.7 fixing security vulnerabilities:

https://github.com/keycloak/keycloak/security

## Purpose
Fix security vulnerablities.

## Approach
Bump keycloak major version.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.