### PR TITLE
KEYCLOAK-48: Upgrade keycloak from 26.1.0 to 26.1.3 fixing Netty CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.1.0
+ARG KEYCLOAK_VERSION=26.1.3
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.1.0
+ARG KEYCLOAK_VERSION=26.1.3
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KEYCLOAK-48

## Purpose
Fix Netty CVE-2025-24970:
https://github.com/netty/netty/security/advisories/GHSA-4g8c-wm8x-jfhw

## Approach
Bump keycloak from 26.1.0 to 26.1.3.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.