### PR TITLE
KEYCLOAK-49: Upgrade KCPLUG_DETECT_FOLIO_USER_VERSION: 1.1.0 → 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 WORKDIR /tmp/keycloak-providers-jars
 
 # FOLIO Keycloak plugins versions to download
-ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.1.0
+ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.2.0
 
 ARG FOLIO_MAVEN_URL=https://repository.folio.org/repository/maven-releases
 

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -6,7 +6,7 @@ FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 WORKDIR /tmp/keycloak-providers-jars
 
 # FOLIO Keycloak plugins versions to download
-ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.1.0
+ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.2.0
 
 # Bouncy Castle JAR versions to download
 ARG BC_FIPS_VERSION=1.0.2.5


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KEYCLOAK-49

Upgrade FOLIO Keycloak plugins fixing Netty CVE-2025-24970: https://github.com/advisories/GHSA-4g8c-wm8x-jfhw

## Purpose
Fix security vulnerability.

## Approach
Bump version of keycloak plugins from 1.1.0 to 1.2.0.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.