### PR TITLE
KEYCLOAK-53: Use KC_BOOTSTRAP_ADMIN_PASSWORD

### DIFF
--- a/folio/configure-realms.sh
+++ b/folio/configure-realms.sh
@@ -14,7 +14,7 @@ function loginAsAdmin() {
     --server "$keycloakUrl" \
     --realm master \
     --user admin \
-    --password "${KEYCLOAK_ADMIN_PASSWORD}" \
+    --password "${KC_BOOTSTRAP_ADMIN_PASSWORD-$KEYCLOAK_ADMIN_PASSWORD}" \
     &> /dev/null
 }
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KEYCLOAK-53

## Purpose

Rename deprecated KEYCLOAK_ADMIN_PASSWORD environment variable.

## Approach

Prefer KC_BOOTSTRAP_ADMIN_PASSWORD over deprecated KEYCLOAK_ADMIN_PASSWORD.

## TODOS and Open Questions

- [x] Check logging

## Learning

The official keycloak 26.0.0 release notes https://www.keycloak.org/docs/latest/upgrading/index.html#admin-bootstrapping-and-recovery say:

> the environment variables KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD have been deprecated. You should use KC_BOOTSTRAP_ADMIN_USERNAME and KC_BOOTSTRAP_ADMIN_PASSWORD instead.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.