### PR TITLE
Replace curl with wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.2.0
 ARG FOLIO_MAVEN_URL=https://repository.folio.org/repository/maven-releases
 
 # Download plugin JAR files
-RUN apk upgrade --no-cache && apk --no-cache add curl \
- && curl -O ${FOLIO_MAVEN_URL}/org/folio/authentication/keycloak-detect-folio-user/${KCPLUG_DETECT_FOLIO_USER_VERSION}/keycloak-detect-folio-user-${KCPLUG_DETECT_FOLIO_USER_VERSION}.jar
+RUN wget ${FOLIO_MAVEN_URL}/org/folio/authentication/keycloak-detect-folio-user/${KCPLUG_DETECT_FOLIO_USER_VERSION}/keycloak-detect-folio-user-${KCPLUG_DETECT_FOLIO_USER_VERSION}.jar
 
 FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION AS builder
 

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -17,11 +17,10 @@ ARG FOLIO_MAVEN_URL=https://repository.folio.org/repository/maven-releases
 ARG BC_MAVEN_URL=https://repo1.maven.org/maven2/org/bouncycastle
 
 # Download Bouncy Castle JAR files
-RUN apk upgrade --no-cache && apk --no-cache add curl \
- && curl -O ${FOLIO_MAVEN_URL}/org/folio/authentication/keycloak-detect-folio-user/${KCPLUG_DETECT_FOLIO_USER_VERSION}/keycloak-detect-folio-user-${KCPLUG_DETECT_FOLIO_USER_VERSION}.jar \
- && curl -O ${BC_MAVEN_URL}/bc-fips/${BC_FIPS_VERSION}/bc-fips-${BC_FIPS_VERSION}.jar \
- && curl -O ${BC_MAVEN_URL}/bctls-fips/${BCTLS_FIPS_VERSION}/bctls-fips-${BCTLS_FIPS_VERSION}.jar \
- && curl -O ${BC_MAVEN_URL}/bcpkix-fips/${BCPKIX_FIPS_VERSION}/bcpkix-fips-${BCPKIX_FIPS_VERSION}.jar
+RUN wget ${FOLIO_MAVEN_URL}/org/folio/authentication/keycloak-detect-folio-user/${KCPLUG_DETECT_FOLIO_USER_VERSION}/keycloak-detect-folio-user-${KCPLUG_DETECT_FOLIO_USER_VERSION}.jar \
+ && wget ${BC_MAVEN_URL}/bc-fips/${BC_FIPS_VERSION}/bc-fips-${BC_FIPS_VERSION}.jar \
+ && wget ${BC_MAVEN_URL}/bctls-fips/${BCTLS_FIPS_VERSION}/bctls-fips-${BCTLS_FIPS_VERSION}.jar \
+ && wget ${BC_MAVEN_URL}/bcpkix-fips/${BCPKIX_FIPS_VERSION}/bcpkix-fips-${BCPKIX_FIPS_VERSION}.jar
 
 FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION AS builder
 


### PR DESCRIPTION
Alpine linux ships with `wget`, not need to install `curl` for a simple download.

## Purpose
Avoid `apk upgrade` and the installation of `curl`.

## Approach
Use `wget` instead.

## TODOS and Open Questions
- [x] Check logging

## Learning
Don't install a package if a similar package is already installed.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.