### PR TITLE
Add missing part for sso only custom theme

### DIFF
--- a/custom-theme-sso-only/login/theme.properties
+++ b/custom-theme-sso-only/login/theme.properties
@@ -6,7 +6,7 @@ styles=node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternf
 
 meta=viewport==width=device-width,initial-scale=1
 
-baseLogoFilesURL=https://eureka-customer-assets.s3.us-west-2.amazonaws.com
+baseLogoFilesURL=${env.BASE_LOGO_FILES_URL:https://eureka-customer-assets.s3.us-west-2.amazonaws.com}
 
 kcHtmlClass=login-body
 kcLoginClass=login-wrapper


### PR DESCRIPTION
## Purpose

Fix missing `env.BASE_LOGO_FILES_URL` for custom-theme-sso-only

## Approach

Update the theme file to be consistent

## TODOS and Open Questions

- [x] Check logging

## Learning

This probably should not be missed in previous PR https://github.com/folio-org/folio-keycloak/pull/29

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.