### PR TITLE
KEYCLOAK-58: Upgrade Keycloak from EOL 26.1 to 26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.1.4
+ARG KEYCLOAK_VERSION=26.2.5
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory
 WORKDIR /tmp/keycloak-providers-jars
 
 # FOLIO Keycloak plugins versions to download
-ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.2.0
+ARG KCPLUG_DETECT_FOLIO_USER_VERSION=26.2.0
 
 ARG FOLIO_MAVEN_URL=https://repository.folio.org/repository/maven-releases
 

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -1,12 +1,12 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.1.4
+ARG KEYCLOAK_VERSION=26.2.5
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory
 WORKDIR /tmp/keycloak-providers-jars
 
 # FOLIO Keycloak plugins versions to download
-ARG KCPLUG_DETECT_FOLIO_USER_VERSION=1.2.0
+ARG KCPLUG_DETECT_FOLIO_USER_VERSION=26.2.0
 
 # Bouncy Castle JAR versions to download
 ARG BC_FIPS_VERSION=1.0.2.5


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KEYCLOAK-58

## Purpose
Keycloak 26.1.* is end-of-life: https://github.com/keycloak/keycloak/security/policy#supported-versions

Upgrade to a supported version.

## Approach
Upgrade to Keycloak 26.2.*

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.