### PR TITLE
KEYCLOAK-60: Downgrade admin-fine-grained-authz from v2 to v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION AS builder
 ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
-ENV KC_FEATURES=scripts,token-exchange,admin-fine-grained-authz:v1
+ENV KC_FEATURES=scripts:v1,token-exchange:v1,admin-fine-grained-authz:v1
 
 COPY --chown=keycloak:keycloak --from=providers_jar_downloader /tmp/keycloak-providers-jars/ /opt/keycloak/providers/
 COPY --chown=keycloak:keycloak libs/folio-scripts.jar /opt/keycloak/providers/

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -27,7 +27,7 @@ FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION AS builder
 ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
-ENV KC_FEATURES=scripts,token-exchange,admin-fine-grained-authz:v1,fips
+ENV KC_FEATURES=scripts:v1,token-exchange:v1,admin-fine-grained-authz:v1,fips:v1
 ENV KC_FIPS_MODE=strict
 
 COPY --chown=keycloak:keycloak --from=providers_jar_downloader /tmp/keycloak-providers-jars/ /opt/keycloak/providers/


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KEYCLOAK-60

## Purpose
To keep our code working we need Keycloak to provide admin-fine-grained-authz:v1 API.
Keycloak since version 26.2.0 disables admin-fine-grained-authz:v1 and enables admin-fine-grained-authz:v2.

## Approach
Downgrade from default v2 to v1.

To avoid a similar problem with the other Keycloak features pinpoint them to the current major version.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added, or removed? admin-fine-grained-authz:v1 API path added
  - [x] There are no breaking changes in this PR.