### PR TITLE
Change JDBC_PING to v2

### DIFF
--- a/cache-ispn-jdbc.xml
+++ b/cache-ispn-jdbc.xml
@@ -7,10 +7,9 @@
   <!-- custom stack goes into the jgroups element -->
   <jgroups>
     <stack name="jdbc-ping-tcp" extends="tcp">
-      <JDBC_PING connection_driver="org.postgresql.Driver"
+      <JDBC_PING2 connection_driver="org.postgresql.Driver"
         connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
         connection_url="jdbc:postgresql://${env.KC_DB_URL_HOST}/${env.KC_DB_URL_DATABASE}"
-        initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, ping_data BYTEA, constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name));"
         info_writer_sleep_time="500"
         remove_all_data_on_view_change="true"
         stack.combine="REPLACE"


### PR DESCRIPTION
## Purpose

The purpose of these changes is to use the latest version of JDBC_PING protocol
Tested on PTF cluster.
Now table jgoup contains all information about the cluster.
Information about nodes, their IP addresses, and their leader is now in a more human-readable format.


<img width="932" height="223" alt="Screenshot 2025-08-13 at 16 15 28" src="https://github.com/user-attachments/assets/17cb7541-939c-4171-b033-25b41a40a91e" />
