### PR TITLE
KEYCLOAK-56: Upgrade to Keycloak 26.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.2.5
+ARG KEYCLOAK_VERSION=26.3.2
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.3.2
+ARG KEYCLOAK_VERSION=26.3.3
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.2.5
+ARG KEYCLOAK_VERSION=26.3.2
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory

--- a/Dockerfile-fips
+++ b/Dockerfile-fips
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.21.2
-ARG KEYCLOAK_VERSION=26.3.2
+ARG KEYCLOAK_VERSION=26.3.3
 FROM alpine:$ALPINE_VERSION AS providers_jar_downloader
 
 # Set the working directory


### PR DESCRIPTION
- Changed base image to v26.3.3
[KEYCLOAK-56](https://folio-org.atlassian.net/browse/KEYCLOAK-56)
