### PR TITLE
Us1493814

### DIFF
--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -44,7 +44,6 @@ get_token() {
     [[ -n "$error_msg" ]] && echo "Details: $error_msg" >&2
     exit 1
   fi
-  TOKEN_TIMESTAMP=$(date +%s)
   echo "$token"
 }
 
@@ -52,8 +51,9 @@ refresh_token_if_needed() {
   local now
   now=$(date +%s)
   local elapsed=$(( now - TOKEN_TIMESTAMP ))
-  if [[ $elapsed -ge 50 ]]; then
+  if [[ $elapsed -ge 300 ]]; then
     TOKEN=$(get_token)
+    TOKEN_TIMESTAMP=$(date +%s)
     echo "  [TOKEN] Refreshed admin token (was ${elapsed}s old)"
   fi
 }
@@ -77,6 +77,7 @@ curl_with_retry() {
     if [[ "$http_code" == "401" ]]; then
       echo "  [RETRY] Got 401, refreshing token (attempt ${attempt}/${MAX_RETRIES})..." >&2
       TOKEN=$(get_token)
+      TOKEN_TIMESTAMP=$(date +%s)
       continue
     fi
 
@@ -111,6 +112,7 @@ curl_delete_with_retry() {
     if [[ "$response" == "401" ]]; then
       echo "    [RETRY] Got 401 on DELETE, refreshing token (attempt ${attempt}/${MAX_RETRIES})..." >&2
       TOKEN=$(get_token)
+      TOKEN_TIMESTAMP=$(date +%s)
       continue
     fi
 
@@ -137,6 +139,7 @@ role_exists() {
 }
 
 TOKEN=$(get_token)
+TOKEN_TIMESTAMP=$(date +%s)
 
 if [[ -n "$TENANT_IDS" ]]; then
   IFS=',' read -ra REALMS <<< "$TENANT_IDS"

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -1,70 +1,69 @@
-#!/bin/bash
-
+#!/bin/bash                                                                                                                                              
 
 set -euo pipefail
 
-KEYCLOAK_URL=${KEYCLOAK_URL:-"http://localhost:8080"}
+KEYCLOAK_URL=${KEYCLOAK_URL:-"http://localhost:8080"}                                                                                                    
 ADMIN_USER=${1:-${KC_ADMIN_USER:-"admin"}}
-ADMIN_PASS=${2:-${KC_ADMIN_PASSWORD:-"admin"}}
-CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}
+ADMIN_PASS=${2:-${KC_ADMIN_PASSWORD:-"admin"}}                                                                                                           
+CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}                                                                                                  
 DRY_RUN=${DRY_RUN:-"true"}
-PAGE_SIZE=${PAGE_SIZE:-100}
-
-# Global Counters
-TOTAL_REALMS_PROCESSED=0
-TOTAL_CLIENTS_CHECKED=0
+PAGE_SIZE=${PAGE_SIZE:-100}                                                                                                                              
+                                                                              
+# Global Counters                                                                                                                                        
+TOTAL_REALMS_PROCESSED=0                                                      
+TOTAL_CLIENTS_CHECKED=0                                                                                                                                  
 TOTAL_DEAD_ROLE_POLICIES=0
-TOTAL_DEAD_PERMISSIONS=0
-
-if [[ "$DRY_RUN" == "true" ]]; then
-  echo "================================================================"
-  echo "RUNNING IN DRY-RUN MODE. Set DRY_RUN=false to perform deletions."
-  echo "================================================================"
-fi
-
-get_token() {
-  local response
+TOTAL_DEAD_PERMISSIONS=0                                                                                                                                 
+                                                                                                                                                         
+if [[ "$DRY_RUN" == "true" ]]; then                                                                                                                      
+  echo "================================================================"                                                                                
+  echo "RUNNING IN DRY-RUN MODE. Set DRY_RUN=false to perform deletions."                                                                                
+  echo "================================================================"                                                                                
+fi                                                                                                                                                       
+                                                                                                                                                         
+get_token() {                                                                                                                                            
+  local response                                                                                                                                         
   response=$(curl -s -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
-    -d "username=${ADMIN_USER}" \
-    -d "password=${ADMIN_PASS}" \
-    -d 'grant_type=password' \
-    -d 'client_id=admin-cli')
+    -d "username=${ADMIN_USER}" \                                                                                                                        
+    -d "password=${ADMIN_PASS}" \                                                                                                                        
+    -d 'grant_type=password' \                                                                                                                           
+    -d 'client_id=admin-cli')                                                                                                                            
+                                                                                                                                                         
+  local token                                                                                                                                            
+  token=$(echo "$response" | jq -r .access_token)                                                                                                        
+  if [[ "$token" == "null" || -z "$token" ]]; then                            
+    local error_msg                                                                                                                                      
+    error_msg=$(echo "$response" | jq -r .error_description)                                                                                             
+    echo "ERROR: Failed to retrieve admin token. Please check credentials." >&2                                                                          
+    [[ -n "$error_msg" ]] && echo "Details: $error_msg" >&2                                                                                              
+    exit 1                                                                                                                                               
+  fi                                                                                                                                                     
+  echo "$token"                                                                                                                                          
+}                                                                             
 
-  local token
-  token=$(echo "$response" | jq -r .access_token)
-  if [[ "$token" == "null" || -z "$token" ]]; then
-    local error_msg
-    error_msg=$(echo "$response" | jq -r .error_description)
-    echo "ERROR: Failed to retrieve admin token. Please check credentials." >&2
-    [[ -n "$error_msg" ]] && echo "Details: $error_msg" >&2
-    exit 1
-  fi
-  echo "$token"
-}
-
-role_exists() {
+role_exists() {                                                                                                                                          
   local realm=$1 role_id=$2 token=$3
-  local code
+  local code                                                                                                                                             
   code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" \
-    "${KEYCLOAK_URL}/admin/realms/${realm}/roles-by-id/${role_id}")
-  [[ "$code" == "200" ]]
-}
-
-TOKEN=$(get_token)
-
-REALMS=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')
-
-for realm in $REALMS; do
-  [[ "$realm" == "master" ]] && continue
-  ((TOTAL_REALMS_PROCESSED++))
+    "${KEYCLOAK_URL}/admin/realms/${realm}/roles-by-id/${role_id}")                                                                                      
+  [[ "$code" == "200" ]]                                                                                                                                 
+}                                                                                                                                                        
+                                                                                                                                                         
+TOKEN=$(get_token)                                                                                                                                       
+ 
+REALMS=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')                                                   
+                                                                              
+for realm in $REALMS; do                                                                                                                                 
+  [[ "$realm" == "master" ]] && continue                                      
+  ((++TOTAL_REALMS_PROCESSED))                                                                                                                           
   echo "Processing realm: $realm"
-
-  clients=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")
-  
-  while read -r client; do
-    [[ -z "$client" ]] && continue
-    ((TOTAL_CLIENTS_CHECKED++))
-    
+                                                                                                                                                         
+  clients=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")                                                   
+                                                                                                                                                         
+  while read -r client; do                                                                                                                               
+    [[ -z "$client" ]] && continue                                            
+    ((++TOTAL_CLIENTS_CHECKED))                                                                                                                          
+                                                                              
     client_uuid=$(echo "$client" | jq -r '.id')
     client_id=$(echo "$client" | jq -r '.clientId')
     echo "  Checking client: $client_id ($client_uuid)"
@@ -72,158 +71,158 @@ for realm in $REALMS; do
     # Initialize variables
     dead_role_policy_ids=()
     dead_permission_ids=()
-    
+
     # --- PHASE 1: Identify all Dead Role Policies (Paginated) ---
     offset=0
     while true; do
       policies_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \
-        "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=role&first=${offset}&max=${PAGE_SIZE}")
-      
-      count=$(echo "$policies_chunk" | jq '. | length')
-      [[ "$count" -eq 0 ]] && break
-
-      while read -r policy; do
-        pid=$(echo "$policy" | jq -r '.id')
-        pname=$(echo "$policy" | jq -r '.name')
-        
-        policy_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${pid}")
-        
-        roles_json=$(echo "$policy_detail" | jq -r '.roles // .config.roles // empty')
-        
-        if [[ -n "$roles_json" ]]; then
-          if [[ "$roles_json" == \[* ]]; then
-             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id')
-          else
-             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id' 2>/dev/null || echo "")
-          fi
-          
-          if [[ -n "$referenced_role_ids" ]]; then
-            total_roles=0
-            existing_roles=0
-            while read -r rid; do
-              [[ -z "$rid" ]] && continue
-              ((total_roles++))
-              if role_exists "$realm" "$rid" "$TOKEN"; then
-                ((existing_roles++))
-              fi
-            done <<< "$referenced_role_ids"
-
-            if [[ $total_roles -gt 0 && $existing_roles -eq 0 ]]; then
-              echo "    Found dead role policy: $pname ($pid)"
-              dead_role_policy_ids=("${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}" "$pid")
-              ((TOTAL_DEAD_ROLE_POLICIES++))
+        "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=role&first=${offset}&max=${PAGE_SIZE}")          
+                                                                                                                                                         
+      count=$(echo "$policies_chunk" | jq '. | length')                                                                                                  
+      [[ "$count" -eq 0 ]] && break                                                                                                                      
+                                                                                                                                                         
+      while read -r policy; do                                                
+        pid=$(echo "$policy" | jq -r '.id')                                                                                                              
+        pname=$(echo "$policy" | jq -r '.name')                               
+                                                                                                                                                         
+        policy_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \                                                                                      
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${pid}")                                            
+                                                                                                                                                         
+        roles_json=$(echo "$policy_detail" | jq -r '.roles // .config.roles // empty')                                                                   
+                                                                                                                                                         
+        if [[ -n "$roles_json" ]]; then                                                                                                                  
+          if [[ "$roles_json" == \[* ]]; then                                 
+             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id')                                                                                  
+          else                                                                                                                                           
+             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id' 2>/dev/null || echo "")                                                           
+          fi                                                                                                                                             
+                                                                              
+          if [[ -n "$referenced_role_ids" ]]; then                                                                                                       
+            total_roles=0                                                     
+            existing_roles=0                                                                                                                             
+            while read -r rid; do                                             
+              [[ -z "$rid" ]] && continue                                                                                                                
+              ((++total_roles))                                                                                                                          
+              if role_exists "$realm" "$rid" "$TOKEN"; then                                                                                              
+                ((++existing_roles))                                                                                                                     
+              fi                                                                                                                                         
+            done <<< "$referenced_role_ids"                                                                                                              
+                                                                                                                                                         
+            if [[ $total_roles -gt 0 && $existing_roles -eq 0 ]]; then                                                                                   
+              echo "    Found dead role policy: $pname ($pid)"                
+              dead_role_policy_ids=("${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}" "$pid")                                                    
+              ((++TOTAL_DEAD_ROLE_POLICIES))                                                                                                             
             fi
-          fi
-        fi
+          fi                                                                                                                                             
+        fi                                                                                                                                               
       done < <(echo "$policies_chunk" | jq -c '.[]')
-
-      [[ "$count" -lt "$PAGE_SIZE" ]] && break
-      ((offset += PAGE_SIZE))
-    done
-
-    if [[ ${#dead_role_policy_ids[@]} -eq 0 ]]; then
-      echo "    No dead role policies found."
-      continue
-    fi
-
-    # --- PHASE 2: Identify Dead Permissions (Paginated) ---
+                                                                                                                                                         
+      [[ "$count" -lt "$PAGE_SIZE" ]] && break                                                                                                           
+      ((offset += PAGE_SIZE))                                                                                                                            
+    done                                                                                                                                                 
+                                                                                                                                                         
+    if [[ ${#dead_role_policy_ids[@]} -eq 0 ]]; then                                                                                                     
+      echo "    No dead role policies found."                                                                                                            
+      continue                                                                                                                                           
+    fi                                                                        
+                                                                                                                                                         
+    # --- PHASE 2: Identify Dead Permissions (Paginated) ---                  
     for type in "scope" "resource"; do
       offset=0
       while true; do
-        perms_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \
+        perms_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \                                                                                        
           "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=${type}&first=${offset}&max=${PAGE_SIZE}")
-        
-        count=$(echo "$perms_chunk" | jq '. | length')
-        [[ "$count" -eq 0 ]] && break
-
-        while read -r perm; do
-          permid=$(echo "$perm" | jq -r '.id')
-          permname=$(echo "$perm" | jq -r '.name')
-          
-          perm_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \
-            "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${permid}")
-          
-          assoc_policies=$(echo "$perm_detail" | jq -r '.associatedPolicies // .config.applyPolicies // empty')
-
-          if [[ -n "$assoc_policies" ]]; then
-            if [[ "$assoc_policies" == \[* ]]; then
-               assoc_ids=$(echo "$assoc_policies" | jq -r '.[].id')
-            else
-               assoc_ids=$(echo "$assoc_policies" | tr ',' '\n')
-            fi
-            
-            if [[ -n "$assoc_ids" ]]; then
-              all_assoc_are_dead=true
-              has_at_least_one_dead=false
-              
-              while read -r aid; do
-                [[ -z "$aid" ]] && continue
-                is_dead=false
+                                                                                                                                                         
+        count=$(echo "$perms_chunk" | jq '. | length')                        
+        [[ "$count" -eq 0 ]] && break                                                                                                                    
+                                                                                                                                                         
+        while read -r perm; do                                                                                                                           
+          permid=$(echo "$perm" | jq -r '.id')                                                                                                           
+          permname=$(echo "$perm" | jq -r '.name')                                                                                                       
+                                                                                                                                                         
+          perm_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \                                                                                      
+            "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${permid}")                                       
+                                                                                                                                                         
+          assoc_policies=$(echo "$perm_detail" | jq -r '.associatedPolicies // .config.applyPolicies // empty')                                          
+                                                                                                                                                         
+          if [[ -n "$assoc_policies" ]]; then                                                                                                            
+            if [[ "$assoc_policies" == \[* ]]; then                           
+               assoc_ids=$(echo "$assoc_policies" | jq -r '.[].id')                                                                                      
+            else                                                                                                                                         
+               assoc_ids=$(echo "$assoc_policies" | tr ',' '\n')                                                                                         
+            fi                                                                                                                                           
+                                                                              
+            if [[ -n "$assoc_ids" ]]; then                                                                                                               
+              all_assoc_are_dead=true                                         
+              has_at_least_one_dead=false                                                                                                                
+                                                                                                                                                         
+              while read -r aid; do                                                                                                                      
+                [[ -z "$aid" ]] && continue                                                                                                              
+                is_dead=false                                                                                                                            
                 for dead_id in "${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}"; do
-                  if [[ "$aid" == "$dead_id" ]]; then
-                    is_dead=true
-                    has_at_least_one_dead=true
-                    break
-                  fi
-                done
-                if [[ "$is_dead" == "false" ]]; then
-                  all_assoc_are_dead=false
-                  break
-                fi
-              done <<< "$assoc_ids"
-
-              if [[ "$has_at_least_one_dead" == "true" && "$all_assoc_are_dead" == "true" ]]; then
-                echo "    Found dead permission: $permname ($permid)"
-                dead_permission_ids=("${dead_permission_ids[@]+"${dead_permission_ids[@]}"}" "$permid")
-                ((TOTAL_DEAD_PERMISSIONS++))
-              fi
-            fi
-          fi
-        done < <(echo "$perms_chunk" | jq -c '.[]')
-
-        [[ "$count" -lt "$PAGE_SIZE" ]] && break
-        ((offset += PAGE_SIZE))
-      done
-    done
-
-    # --- PHASE 3: Deletion ---
+                  if [[ "$aid" == "$dead_id" ]]; then                                                                                                    
+                    is_dead=true                                                                                                                         
+                    has_at_least_one_dead=true                                                                                                           
+                    break                                                                                                                                
+                  fi                                                          
+                done                                                                                                                                     
+                if [[ "$is_dead" == "false" ]]; then                          
+                  all_assoc_are_dead=false                                                                                                               
+                  break                                                                                                                                  
+                fi                                                                                                                                       
+              done <<< "$assoc_ids"                                                                                                                      
+                                                                                                                                                         
+              if [[ "$has_at_least_one_dead" == "true" && "$all_assoc_are_dead" == "true" ]]; then                                                       
+                echo "    Found dead permission: $permname ($permid)"                                                                                    
+                dead_permission_ids=("${dead_permission_ids[@]+"${dead_permission_ids[@]}"}" "$permid")                                                  
+                ((++TOTAL_DEAD_PERMISSIONS))                                                                                                             
+              fi                                                                                                                                         
+            fi                                                                                                                                           
+          fi                                                                                                                                             
+        done < <(echo "$perms_chunk" | jq -c '.[]')                                                                                                      
+                                                                                                                                                         
+        [[ "$count" -lt "$PAGE_SIZE" ]] && break                                                                                                         
+        ((offset += PAGE_SIZE))                                                                                                                          
+      done                                                                                                                                               
+    done                                                                      
+                                                                                                                                                         
+    # --- PHASE 3: Deletion ---                                                                                                                          
     for dpid in ${dead_permission_ids[@]+"${dead_permission_ids[@]}"}; do
-      if [[ "$DRY_RUN" == "true" ]]; then
-        echo "    [DRY-RUN] Would delete permission $dpid"
-      else
-        echo "    Deleting permission $dpid..."
-        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+      if [[ "$DRY_RUN" == "true" ]]; then                                                                                                                
+        echo "    [DRY-RUN] Would delete permission $dpid"                                                                                               
+      else                                                                                                                                               
+        echo "    Deleting permission $dpid..."                                                                                                          
+        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \                                                                                            
           "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${dpid}"
-      fi
-    done
-
-    for drpid in ${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}; do
+      fi                                                                                                                                                 
+    done                                                                      
+                                                                                                                                                         
+    for drpid in ${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}; do                                                                             
       if [[ "$DRY_RUN" == "true" ]]; then
-        echo "    [DRY-RUN] Would delete role policy $drpid"
-      else
-        echo "    Deleting role policy $drpid..."
-        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${drpid}"
-      fi
-    done
-
-  done < <(echo "$clients" | jq -c ".[] | select(.clientId | test(\"$CLIENT_ID_PATTERN\")) | select(.authorizationServicesEnabled == true)")
-done
-
-echo ""
+        echo "    [DRY-RUN] Would delete role policy $drpid"                                                                                             
+      else                                                                                                                                               
+        echo "    Deleting role policy $drpid..."                                                                                                        
+        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \                                                                                            
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${drpid}"                                           
+      fi                                                                                                                                                 
+    done                                                                                                                                                 
+                                                                                                                                                         
+  done < <(echo "$clients" | jq -c ".[] | select(.clientId | test(\"$CLIENT_ID_PATTERN\")) | select(.authorizationServicesEnabled == true)")             
+done                                                                          
+                                                                                                                                                         
+echo ""                                                                       
 echo "================================================================"
 echo "SUMMARY REPORT"
 echo "================================================================"
-echo "Realms processed:        $TOTAL_REALMS_PROCESSED"
-echo "Clients checked:         $TOTAL_CLIENTS_CHECKED"
-echo "----------------------------------------------------------------"
-if [[ "$DRY_RUN" == "true" ]]; then
-  echo "Dead Role Policies found: $TOTAL_DEAD_ROLE_POLICIES (NOT deleted)"
-  echo "Dead Permissions found:   $TOTAL_DEAD_PERMISSIONS (NOT deleted)"
-else
-  echo "Dead Role Policies deleted: $TOTAL_DEAD_ROLE_POLICIES"
-  echo "Dead Permissions deleted:   $TOTAL_DEAD_PERMISSIONS"
-fi
-echo "================================================================"
+echo "Realms processed:        $TOTAL_REALMS_PROCESSED"                                                                                                  
+echo "Clients checked:         $TOTAL_CLIENTS_CHECKED"                                                                                                   
+echo "----------------------------------------------------------------"                                                                                  
+if [[ "$DRY_RUN" == "true" ]]; then                                                                                                                      
+  echo "Dead Role Policies found: $TOTAL_DEAD_ROLE_POLICIES (NOT deleted)"                                                                               
+  echo "Dead Permissions found:   $TOTAL_DEAD_PERMISSIONS (NOT deleted)"                                                                                 
+else                                                                                                                                                     
+  echo "Dead Role Policies deleted: $TOTAL_DEAD_ROLE_POLICIES"                                                                                           
+  echo "Dead Permissions deleted:   $TOTAL_DEAD_PERMISSIONS"                                                                                             
+fi                                                                                                                                                       
+echo "================================================================"                                                                                  
 echo "Done."

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -10,6 +10,8 @@ CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}
 DRY_RUN=${DRY_RUN:-"true"}
 PAGE_SIZE=${PAGE_SIZE:-100}
 TENANT_IDS=${TENANT_IDS:-""}
+MAX_RETRIES=${MAX_RETRIES:-3}
+RETRY_DELAY=${RETRY_DELAY:-5}
 
 # Global Counters
 TOTAL_REALMS_PROCESSED=0
@@ -22,6 +24,8 @@ if [[ "$DRY_RUN" == "true" ]]; then
   echo "RUNNING IN DRY-RUN MODE. Set DRY_RUN=false to perform deletions."
   echo "================================================================"
 fi
+
+TOKEN_TIMESTAMP=0
 
 get_token() {
   local response
@@ -40,7 +44,88 @@ get_token() {
     [[ -n "$error_msg" ]] && echo "Details: $error_msg" >&2
     exit 1
   fi
+  TOKEN_TIMESTAMP=$(date +%s)
   echo "$token"
+}
+
+refresh_token_if_needed() {
+  local now
+  now=$(date +%s)
+  local elapsed=$(( now - TOKEN_TIMESTAMP ))
+  if [[ $elapsed -ge 50 ]]; then
+    TOKEN=$(get_token)
+    echo "  [TOKEN] Refreshed admin token (was ${elapsed}s old)"
+  fi
+}
+
+# Curl wrapper with retry logic and HTTP status checking.
+# Usage: curl_with_retry [-X METHOD] URL
+# Outputs response body to stdout. Exits on persistent failure.
+curl_with_retry() {
+  local attempt=0 http_code body response
+  while (( attempt < MAX_RETRIES )); do
+    ((++attempt))
+    response=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $TOKEN" "$@")
+    http_code=$(echo "$response" | tail -1)
+    body=$(echo "$response" | sed '$d')
+
+    if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+      echo "$body"
+      return 0
+    fi
+
+    if [[ "$http_code" == "401" ]]; then
+      echo "  [RETRY] Got 401, refreshing token (attempt ${attempt}/${MAX_RETRIES})..." >&2
+      TOKEN=$(get_token)
+      continue
+    fi
+
+    if [[ "$http_code" =~ ^5[0-9][0-9]$ ]] && (( attempt < MAX_RETRIES )); then
+      echo "  [RETRY] Got HTTP ${http_code}, retrying in ${RETRY_DELAY}s (attempt ${attempt}/${MAX_RETRIES})..." >&2
+      sleep "$RETRY_DELAY"
+      continue
+    fi
+
+    echo "ERROR: HTTP ${http_code} after ${attempt} attempts for: curl $*" >&2
+    echo "$body" >&2
+    return 1
+  done
+
+  echo "ERROR: Exhausted ${MAX_RETRIES} retries for: curl $*" >&2
+  return 1
+}
+
+# DELETE wrapper with retry and status verification.
+# Returns 0 on success (2xx), 1 on failure.
+curl_delete_with_retry() {
+  local attempt=0 http_code response
+  while (( attempt < MAX_RETRIES )); do
+    ((++attempt))
+    refresh_token_if_needed
+    response=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE -H "Authorization: Bearer $TOKEN" "$@")
+
+    if [[ "$response" =~ ^2[0-9][0-9]$ ]]; then
+      return 0
+    fi
+
+    if [[ "$response" == "401" ]]; then
+      echo "    [RETRY] Got 401 on DELETE, refreshing token (attempt ${attempt}/${MAX_RETRIES})..." >&2
+      TOKEN=$(get_token)
+      continue
+    fi
+
+    if [[ "$response" =~ ^5[0-9][0-9]$ ]] && (( attempt < MAX_RETRIES )); then
+      echo "    [RETRY] Got HTTP ${response} on DELETE, retrying in ${RETRY_DELAY}s (attempt ${attempt}/${MAX_RETRIES})..." >&2
+      sleep "$RETRY_DELAY"
+      continue
+    fi
+
+    echo "    WARNING: DELETE returned HTTP ${response} after ${attempt} attempts for: $*" >&2
+    return 1
+  done
+
+  echo "    WARNING: DELETE exhausted ${MAX_RETRIES} retries for: $*" >&2
+  return 1
 }
 
 role_exists() {
@@ -55,29 +140,35 @@ TOKEN=$(get_token)
 
 if [[ -n "$TENANT_IDS" ]]; then
   IFS=',' read -ra REALMS <<< "$TENANT_IDS"
+  # Remove duplicates while preserving order
+  declare -A seen_realms
+  unique_realms=()
+  for r in "${REALMS[@]}"; do
+    if [[ -z "${seen_realms[$r]+x}" ]]; then
+      seen_realms[$r]=1
+      unique_realms+=("$r")
+    fi
+  done
+  REALMS=("${unique_realms[@]}")
+  unset seen_realms unique_realms
   echo "Using specified realms: ${REALMS[*]}"
 else
-  mapfile -t REALMS < <(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')
+  mapfile -t REALMS < <(curl_with_retry "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')
   echo "Fetched all realms from Keycloak (${#REALMS[@]} total)"
 fi
 
 for realm in "${REALMS[@]}"; do
   [[ "$realm" == "master" ]] && continue
   ((++TOTAL_REALMS_PROCESSED))
+  refresh_token_if_needed
   echo "Processing realm: $realm"
 
-  clients=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")
-  http_code=$(echo "$clients" | tail -1)
-  clients=$(echo "$clients" | sed '$d')
-
-  if [[ "$http_code" != "200" ]]; then
-    echo "  ERROR: Realm '$realm' not found or not accessible (HTTP $http_code). Aborting."
-    exit 1
-  fi
+  clients=$(curl_with_retry "${KEYCLOAK_URL}/admin/realms/${realm}/clients")
 
   while read -r client; do
     [[ -z "$client" ]] && continue
     ((++TOTAL_CLIENTS_CHECKED))
+    refresh_token_if_needed
 
     client_uuid=$(echo "$client" | jq -r '.id')
     client_id=$(echo "$client" | jq -r '.clientId')
@@ -86,11 +177,13 @@ for realm in "${REALMS[@]}"; do
     # Initialize variables
     dead_role_policy_ids=()
     dead_permission_ids=()
+    declare -A dead_role_policy_set=()
     
     # --- PHASE 1: Identify all Dead Role Policies (Paginated) ---
     offset=0
     while true; do
-      policies_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \
+      refresh_token_if_needed
+      policies_chunk=$(curl_with_retry \
         "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=role&first=${offset}&max=${PAGE_SIZE}")
       
       count=$(echo "$policies_chunk" | jq '. | length')
@@ -100,7 +193,7 @@ for realm in "${REALMS[@]}"; do
         pid=$(echo "$policy" | jq -r '.id')
         pname=$(echo "$policy" | jq -r '.name')
         
-        policy_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \
+        policy_detail=$(curl_with_retry \
           "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${pid}")
         
         roles_json=$(echo "$policy_detail" | jq -r '.roles // .config.roles // empty')
@@ -126,6 +219,7 @@ for realm in "${REALMS[@]}"; do
             if [[ $total_roles -gt 0 && $existing_roles -eq 0 ]]; then
               echo "    Found dead role policy: $pname ($pid)"
               dead_role_policy_ids=("${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}" "$pid")
+              dead_role_policy_set[$pid]=1
               ((++TOTAL_DEAD_ROLE_POLICIES))
             fi
           fi
@@ -145,7 +239,8 @@ for realm in "${REALMS[@]}"; do
     for type in "scope" "resource"; do
       offset=0
       while true; do
-        perms_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \
+        refresh_token_if_needed
+        perms_chunk=$(curl_with_retry \
           "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=${type}&first=${offset}&max=${PAGE_SIZE}")
         
         count=$(echo "$perms_chunk" | jq '. | length')
@@ -155,7 +250,7 @@ for realm in "${REALMS[@]}"; do
           permid=$(echo "$perm" | jq -r '.id')
           permname=$(echo "$perm" | jq -r '.name')
           
-          perm_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \
+          perm_detail=$(curl_with_retry \
             "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${permid}")
           
           assoc_policies=$(echo "$perm_detail" | jq -r '.associatedPolicies // .config.applyPolicies // empty')
@@ -173,15 +268,9 @@ for realm in "${REALMS[@]}"; do
               
               while read -r aid; do
                 [[ -z "$aid" ]] && continue
-                is_dead=false
-                for dead_id in "${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}"; do
-                  if [[ "$aid" == "$dead_id" ]]; then
-                    is_dead=true
-                    has_at_least_one_dead=true
-                    break
-                  fi
-                done
-                if [[ "$is_dead" == "false" ]]; then
+                if [[ -n "${dead_role_policy_set[$aid]+x}" ]]; then
+                  has_at_least_one_dead=true
+                else
                   all_assoc_are_dead=false
                   break
                 fi
@@ -207,8 +296,10 @@ for realm in "${REALMS[@]}"; do
         echo "    [DRY-RUN] Would delete permission $dpid"
       else
         echo "    Deleting permission $dpid..."
-        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${dpid}"
+        if ! curl_delete_with_retry \
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${dpid}"; then
+          echo "    WARNING: Failed to delete permission $dpid"
+        fi
       fi
     done
 
@@ -217,12 +308,14 @@ for realm in "${REALMS[@]}"; do
         echo "    [DRY-RUN] Would delete role policy $drpid"
       else
         echo "    Deleting role policy $drpid..."
-        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${drpid}"
+        if ! curl_delete_with_retry \
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${drpid}"; then
+          echo "    WARNING: Failed to delete role policy $drpid"
+        fi
       fi
     done
 
-  done < <(echo "$clients" | jq -c ".[] | select(.clientId | test(\"$CLIENT_ID_PATTERN\")) | select(.authorizationServicesEnabled == true)")
+  done < <(echo "$clients" | jq -c --arg pattern "$CLIENT_ID_PATTERN" '.[] | select(.clientId | test($pattern)) | select(.authorizationServicesEnabled == true)')
 done
 
 echo ""

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -66,8 +66,15 @@ for realm in "${REALMS[@]}"; do
   ((++TOTAL_REALMS_PROCESSED))
   echo "Processing realm: $realm"
 
-  clients=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")
-  
+  clients=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")
+  http_code=$(echo "$clients" | tail -1)
+  clients=$(echo "$clients" | sed '$d')
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "  ERROR: Realm '$realm' not found or not accessible (HTTP $http_code). Aborting."
+    exit 1
+  fi
+
   while read -r client; do
     [[ -z "$client" ]] && continue
     ((++TOTAL_CLIENTS_CHECKED))

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -9,6 +9,7 @@ ADMIN_PASS=${2:-${KC_ADMIN_PASSWORD:-"admin"}}
 CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}
 DRY_RUN=${DRY_RUN:-"true"}
 PAGE_SIZE=${PAGE_SIZE:-100}
+REALMS_FILTER=${REALMS_FILTER:-""}
 
 # Global Counters
 TOTAL_REALMS_PROCESSED=0
@@ -52,9 +53,15 @@ role_exists() {
 
 TOKEN=$(get_token)
 
-REALMS=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')
+if [[ -n "$REALMS_FILTER" ]]; then
+  IFS=',' read -ra REALMS <<< "$REALMS_FILTER"
+  echo "Using specified realms: ${REALMS[*]}"
+else
+  mapfile -t REALMS < <(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')
+  echo "Fetched all realms from Keycloak (${#REALMS[@]} total)"
+fi
 
-for realm in $REALMS; do
+for realm in "${REALMS[@]}"; do
   [[ "$realm" == "master" ]] && continue
   ((++TOTAL_REALMS_PROCESSED))
   echo "Processing realm: $realm"
@@ -148,7 +155,7 @@ for realm in $REALMS; do
 
           if [[ -n "$assoc_policies" ]]; then
             if [[ "$assoc_policies" == \[* ]]; then
-               assoc_ids=$(echo "$assoc_policies" | jq -r '.[].id')
+               assoc_ids=$(echo "$assoc_policies" | jq -r '.[] | if type == "object" then .id else . end')
             else
                assoc_ids=$(echo "$assoc_policies" | tr ',' '\n')
             fi

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -9,7 +9,7 @@ ADMIN_PASS=${2:-${KC_ADMIN_PASSWORD:-"admin"}}
 CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}
 DRY_RUN=${DRY_RUN:-"true"}
 PAGE_SIZE=${PAGE_SIZE:-100}
-REALMS_FILTER=${REALMS_FILTER:-""}
+TENANT_IDS=${TENANT_IDS:-""}
 
 # Global Counters
 TOTAL_REALMS_PROCESSED=0
@@ -53,8 +53,8 @@ role_exists() {
 
 TOKEN=$(get_token)
 
-if [[ -n "$REALMS_FILTER" ]]; then
-  IFS=',' read -ra REALMS <<< "$REALMS_FILTER"
+if [[ -n "$TENANT_IDS" ]]; then
+  IFS=',' read -ra REALMS <<< "$TENANT_IDS"
   echo "Using specified realms: ${REALMS[*]}"
 else
   mapfile -t REALMS < <(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -1,69 +1,70 @@
-#!/bin/bash                                                                                                                                              
+#!/bin/bash
+
 
 set -euo pipefail
 
-KEYCLOAK_URL=${KEYCLOAK_URL:-"http://localhost:8080"}                                                                                                    
+KEYCLOAK_URL=${KEYCLOAK_URL:-"http://localhost:8080"}
 ADMIN_USER=${1:-${KC_ADMIN_USER:-"admin"}}
-ADMIN_PASS=${2:-${KC_ADMIN_PASSWORD:-"admin"}}                                                                                                           
-CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}                                                                                                  
+ADMIN_PASS=${2:-${KC_ADMIN_PASSWORD:-"admin"}}
+CLIENT_ID_PATTERN=${CLIENT_ID_PATTERN:-"-application$"}
 DRY_RUN=${DRY_RUN:-"true"}
-PAGE_SIZE=${PAGE_SIZE:-100}                                                                                                                              
-                                                                              
-# Global Counters                                                                                                                                        
-TOTAL_REALMS_PROCESSED=0                                                      
-TOTAL_CLIENTS_CHECKED=0                                                                                                                                  
-TOTAL_DEAD_ROLE_POLICIES=0
-TOTAL_DEAD_PERMISSIONS=0                                                                                                                                 
-                                                                                                                                                         
-if [[ "$DRY_RUN" == "true" ]]; then                                                                                                                      
-  echo "================================================================"                                                                                
-  echo "RUNNING IN DRY-RUN MODE. Set DRY_RUN=false to perform deletions."                                                                                
-  echo "================================================================"                                                                                
-fi                                                                                                                                                       
-                                                                                                                                                         
-get_token() {                                                                                                                                            
-  local response                                                                                                                                         
-  response=$(curl -s -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
-    -d "username=${ADMIN_USER}" \                                                                                                                        
-    -d "password=${ADMIN_PASS}" \                                                                                                                        
-    -d 'grant_type=password' \                                                                                                                           
-    -d 'client_id=admin-cli')                                                                                                                            
-                                                                                                                                                         
-  local token                                                                                                                                            
-  token=$(echo "$response" | jq -r .access_token)                                                                                                        
-  if [[ "$token" == "null" || -z "$token" ]]; then                            
-    local error_msg                                                                                                                                      
-    error_msg=$(echo "$response" | jq -r .error_description)                                                                                             
-    echo "ERROR: Failed to retrieve admin token. Please check credentials." >&2                                                                          
-    [[ -n "$error_msg" ]] && echo "Details: $error_msg" >&2                                                                                              
-    exit 1                                                                                                                                               
-  fi                                                                                                                                                     
-  echo "$token"                                                                                                                                          
-}                                                                             
+PAGE_SIZE=${PAGE_SIZE:-100}
 
-role_exists() {                                                                                                                                          
+# Global Counters
+TOTAL_REALMS_PROCESSED=0
+TOTAL_CLIENTS_CHECKED=0
+TOTAL_DEAD_ROLE_POLICIES=0
+TOTAL_DEAD_PERMISSIONS=0
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "================================================================"
+  echo "RUNNING IN DRY-RUN MODE. Set DRY_RUN=false to perform deletions."
+  echo "================================================================"
+fi
+
+get_token() {
+  local response
+  response=$(curl -s -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+    -d "username=${ADMIN_USER}" \
+    -d "password=${ADMIN_PASS}" \
+    -d 'grant_type=password' \
+    -d 'client_id=admin-cli')
+
+  local token
+  token=$(echo "$response" | jq -r .access_token)
+  if [[ "$token" == "null" || -z "$token" ]]; then
+    local error_msg
+    error_msg=$(echo "$response" | jq -r .error_description)
+    echo "ERROR: Failed to retrieve admin token. Please check credentials." >&2
+    [[ -n "$error_msg" ]] && echo "Details: $error_msg" >&2
+    exit 1
+  fi
+  echo "$token"
+}
+
+role_exists() {
   local realm=$1 role_id=$2 token=$3
-  local code                                                                                                                                             
+  local code
   code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" \
-    "${KEYCLOAK_URL}/admin/realms/${realm}/roles-by-id/${role_id}")                                                                                      
-  [[ "$code" == "200" ]]                                                                                                                                 
-}                                                                                                                                                        
-                                                                                                                                                         
-TOKEN=$(get_token)                                                                                                                                       
- 
-REALMS=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')                                                   
-                                                                              
-for realm in $REALMS; do                                                                                                                                 
-  [[ "$realm" == "master" ]] && continue                                      
-  ((++TOTAL_REALMS_PROCESSED))                                                                                                                           
+    "${KEYCLOAK_URL}/admin/realms/${realm}/roles-by-id/${role_id}")
+  [[ "$code" == "200" ]]
+}
+
+TOKEN=$(get_token)
+
+REALMS=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms" | jq -r '.[].realm')
+
+for realm in $REALMS; do
+  [[ "$realm" == "master" ]] && continue
+  ((++TOTAL_REALMS_PROCESSED))
   echo "Processing realm: $realm"
-                                                                                                                                                         
-  clients=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")                                                   
-                                                                                                                                                         
-  while read -r client; do                                                                                                                               
-    [[ -z "$client" ]] && continue                                            
-    ((++TOTAL_CLIENTS_CHECKED))                                                                                                                          
-                                                                              
+
+  clients=$(curl -s -H "Authorization: Bearer $TOKEN" "${KEYCLOAK_URL}/admin/realms/${realm}/clients")
+  
+  while read -r client; do
+    [[ -z "$client" ]] && continue
+    ((++TOTAL_CLIENTS_CHECKED))
+
     client_uuid=$(echo "$client" | jq -r '.id')
     client_id=$(echo "$client" | jq -r '.clientId')
     echo "  Checking client: $client_id ($client_uuid)"
@@ -71,158 +72,158 @@ for realm in $REALMS; do
     # Initialize variables
     dead_role_policy_ids=()
     dead_permission_ids=()
-
+    
     # --- PHASE 1: Identify all Dead Role Policies (Paginated) ---
     offset=0
     while true; do
       policies_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \
-        "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=role&first=${offset}&max=${PAGE_SIZE}")          
-                                                                                                                                                         
-      count=$(echo "$policies_chunk" | jq '. | length')                                                                                                  
-      [[ "$count" -eq 0 ]] && break                                                                                                                      
-                                                                                                                                                         
-      while read -r policy; do                                                
-        pid=$(echo "$policy" | jq -r '.id')                                                                                                              
-        pname=$(echo "$policy" | jq -r '.name')                               
-                                                                                                                                                         
-        policy_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \                                                                                      
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${pid}")                                            
-                                                                                                                                                         
-        roles_json=$(echo "$policy_detail" | jq -r '.roles // .config.roles // empty')                                                                   
-                                                                                                                                                         
-        if [[ -n "$roles_json" ]]; then                                                                                                                  
-          if [[ "$roles_json" == \[* ]]; then                                 
-             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id')                                                                                  
-          else                                                                                                                                           
-             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id' 2>/dev/null || echo "")                                                           
-          fi                                                                                                                                             
-                                                                              
-          if [[ -n "$referenced_role_ids" ]]; then                                                                                                       
-            total_roles=0                                                     
-            existing_roles=0                                                                                                                             
-            while read -r rid; do                                             
-              [[ -z "$rid" ]] && continue                                                                                                                
-              ((++total_roles))                                                                                                                          
-              if role_exists "$realm" "$rid" "$TOKEN"; then                                                                                              
-                ((++existing_roles))                                                                                                                     
-              fi                                                                                                                                         
-            done <<< "$referenced_role_ids"                                                                                                              
-                                                                                                                                                         
-            if [[ $total_roles -gt 0 && $existing_roles -eq 0 ]]; then                                                                                   
-              echo "    Found dead role policy: $pname ($pid)"                
-              dead_role_policy_ids=("${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}" "$pid")                                                    
-              ((++TOTAL_DEAD_ROLE_POLICIES))                                                                                                             
+        "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=role&first=${offset}&max=${PAGE_SIZE}")
+      
+      count=$(echo "$policies_chunk" | jq '. | length')
+      [[ "$count" -eq 0 ]] && break
+
+      while read -r policy; do
+        pid=$(echo "$policy" | jq -r '.id')
+        pname=$(echo "$policy" | jq -r '.name')
+        
+        policy_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${pid}")
+        
+        roles_json=$(echo "$policy_detail" | jq -r '.roles // .config.roles // empty')
+        
+        if [[ -n "$roles_json" ]]; then
+          if [[ "$roles_json" == \[* ]]; then
+             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id')
+          else
+             referenced_role_ids=$(echo "$roles_json" | jq -r '.[].id' 2>/dev/null || echo "")
+          fi
+          
+          if [[ -n "$referenced_role_ids" ]]; then
+            total_roles=0
+            existing_roles=0
+            while read -r rid; do
+              [[ -z "$rid" ]] && continue
+              ((++total_roles))
+              if role_exists "$realm" "$rid" "$TOKEN"; then
+                ((++existing_roles))
+              fi
+            done <<< "$referenced_role_ids"
+
+            if [[ $total_roles -gt 0 && $existing_roles -eq 0 ]]; then
+              echo "    Found dead role policy: $pname ($pid)"
+              dead_role_policy_ids=("${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}" "$pid")
+              ((++TOTAL_DEAD_ROLE_POLICIES))
             fi
-          fi                                                                                                                                             
-        fi                                                                                                                                               
+          fi
+        fi
       done < <(echo "$policies_chunk" | jq -c '.[]')
-                                                                                                                                                         
-      [[ "$count" -lt "$PAGE_SIZE" ]] && break                                                                                                           
-      ((offset += PAGE_SIZE))                                                                                                                            
-    done                                                                                                                                                 
-                                                                                                                                                         
-    if [[ ${#dead_role_policy_ids[@]} -eq 0 ]]; then                                                                                                     
-      echo "    No dead role policies found."                                                                                                            
-      continue                                                                                                                                           
-    fi                                                                        
-                                                                                                                                                         
-    # --- PHASE 2: Identify Dead Permissions (Paginated) ---                  
+
+      [[ "$count" -lt "$PAGE_SIZE" ]] && break
+      ((offset += PAGE_SIZE))
+    done
+
+    if [[ ${#dead_role_policy_ids[@]} -eq 0 ]]; then
+      echo "    No dead role policies found."
+      continue
+    fi
+
+    # --- PHASE 2: Identify Dead Permissions (Paginated) ---
     for type in "scope" "resource"; do
       offset=0
       while true; do
-        perms_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \                                                                                        
+        perms_chunk=$(curl -s -H "Authorization: Bearer $TOKEN" \
           "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy?type=${type}&first=${offset}&max=${PAGE_SIZE}")
-                                                                                                                                                         
-        count=$(echo "$perms_chunk" | jq '. | length')                        
-        [[ "$count" -eq 0 ]] && break                                                                                                                    
-                                                                                                                                                         
-        while read -r perm; do                                                                                                                           
-          permid=$(echo "$perm" | jq -r '.id')                                                                                                           
-          permname=$(echo "$perm" | jq -r '.name')                                                                                                       
-                                                                                                                                                         
-          perm_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \                                                                                      
-            "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${permid}")                                       
-                                                                                                                                                         
-          assoc_policies=$(echo "$perm_detail" | jq -r '.associatedPolicies // .config.applyPolicies // empty')                                          
-                                                                                                                                                         
-          if [[ -n "$assoc_policies" ]]; then                                                                                                            
-            if [[ "$assoc_policies" == \[* ]]; then                           
-               assoc_ids=$(echo "$assoc_policies" | jq -r '.[].id')                                                                                      
-            else                                                                                                                                         
-               assoc_ids=$(echo "$assoc_policies" | tr ',' '\n')                                                                                         
-            fi                                                                                                                                           
-                                                                              
-            if [[ -n "$assoc_ids" ]]; then                                                                                                               
-              all_assoc_are_dead=true                                         
-              has_at_least_one_dead=false                                                                                                                
-                                                                                                                                                         
-              while read -r aid; do                                                                                                                      
-                [[ -z "$aid" ]] && continue                                                                                                              
-                is_dead=false                                                                                                                            
+        
+        count=$(echo "$perms_chunk" | jq '. | length')
+        [[ "$count" -eq 0 ]] && break
+
+        while read -r perm; do
+          permid=$(echo "$perm" | jq -r '.id')
+          permname=$(echo "$perm" | jq -r '.name')
+          
+          perm_detail=$(curl -s -H "Authorization: Bearer $TOKEN" \
+            "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${permid}")
+          
+          assoc_policies=$(echo "$perm_detail" | jq -r '.associatedPolicies // .config.applyPolicies // empty')
+
+          if [[ -n "$assoc_policies" ]]; then
+            if [[ "$assoc_policies" == \[* ]]; then
+               assoc_ids=$(echo "$assoc_policies" | jq -r '.[].id')
+            else
+               assoc_ids=$(echo "$assoc_policies" | tr ',' '\n')
+            fi
+            
+            if [[ -n "$assoc_ids" ]]; then
+              all_assoc_are_dead=true
+              has_at_least_one_dead=false
+              
+              while read -r aid; do
+                [[ -z "$aid" ]] && continue
+                is_dead=false
                 for dead_id in "${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}"; do
-                  if [[ "$aid" == "$dead_id" ]]; then                                                                                                    
-                    is_dead=true                                                                                                                         
-                    has_at_least_one_dead=true                                                                                                           
-                    break                                                                                                                                
-                  fi                                                          
-                done                                                                                                                                     
-                if [[ "$is_dead" == "false" ]]; then                          
-                  all_assoc_are_dead=false                                                                                                               
-                  break                                                                                                                                  
-                fi                                                                                                                                       
-              done <<< "$assoc_ids"                                                                                                                      
-                                                                                                                                                         
-              if [[ "$has_at_least_one_dead" == "true" && "$all_assoc_are_dead" == "true" ]]; then                                                       
-                echo "    Found dead permission: $permname ($permid)"                                                                                    
-                dead_permission_ids=("${dead_permission_ids[@]+"${dead_permission_ids[@]}"}" "$permid")                                                  
-                ((++TOTAL_DEAD_PERMISSIONS))                                                                                                             
-              fi                                                                                                                                         
-            fi                                                                                                                                           
-          fi                                                                                                                                             
-        done < <(echo "$perms_chunk" | jq -c '.[]')                                                                                                      
-                                                                                                                                                         
-        [[ "$count" -lt "$PAGE_SIZE" ]] && break                                                                                                         
-        ((offset += PAGE_SIZE))                                                                                                                          
-      done                                                                                                                                               
-    done                                                                      
-                                                                                                                                                         
-    # --- PHASE 3: Deletion ---                                                                                                                          
+                  if [[ "$aid" == "$dead_id" ]]; then
+                    is_dead=true
+                    has_at_least_one_dead=true
+                    break
+                  fi
+                done
+                if [[ "$is_dead" == "false" ]]; then
+                  all_assoc_are_dead=false
+                  break
+                fi
+              done <<< "$assoc_ids"
+
+              if [[ "$has_at_least_one_dead" == "true" && "$all_assoc_are_dead" == "true" ]]; then
+                echo "    Found dead permission: $permname ($permid)"
+                dead_permission_ids=("${dead_permission_ids[@]+"${dead_permission_ids[@]}"}" "$permid")
+                ((++TOTAL_DEAD_PERMISSIONS))
+              fi
+            fi
+          fi
+        done < <(echo "$perms_chunk" | jq -c '.[]')
+
+        [[ "$count" -lt "$PAGE_SIZE" ]] && break
+        ((offset += PAGE_SIZE))
+      done
+    done
+
+    # --- PHASE 3: Deletion ---
     for dpid in ${dead_permission_ids[@]+"${dead_permission_ids[@]}"}; do
-      if [[ "$DRY_RUN" == "true" ]]; then                                                                                                                
-        echo "    [DRY-RUN] Would delete permission $dpid"                                                                                               
-      else                                                                                                                                               
-        echo "    Deleting permission $dpid..."                                                                                                          
-        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \                                                                                            
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${dpid}"
-      fi                                                                                                                                                 
-    done                                                                      
-                                                                                                                                                         
-    for drpid in ${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}; do                                                                             
       if [[ "$DRY_RUN" == "true" ]]; then
-        echo "    [DRY-RUN] Would delete role policy $drpid"                                                                                             
-      else                                                                                                                                               
-        echo "    Deleting role policy $drpid..."                                                                                                        
-        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \                                                                                            
-          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${drpid}"                                           
-      fi                                                                                                                                                 
-    done                                                                                                                                                 
-                                                                                                                                                         
-  done < <(echo "$clients" | jq -c ".[] | select(.clientId | test(\"$CLIENT_ID_PATTERN\")) | select(.authorizationServicesEnabled == true)")             
-done                                                                          
-                                                                                                                                                         
-echo ""                                                                       
+        echo "    [DRY-RUN] Would delete permission $dpid"
+      else
+        echo "    Deleting permission $dpid..."
+        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${dpid}"
+      fi
+    done
+
+    for drpid in ${dead_role_policy_ids[@]+"${dead_role_policy_ids[@]}"}; do
+      if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    [DRY-RUN] Would delete role policy $drpid"
+      else
+        echo "    Deleting role policy $drpid..."
+        curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+          "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}/authz/resource-server/policy/${drpid}"
+      fi
+    done
+
+  done < <(echo "$clients" | jq -c ".[] | select(.clientId | test(\"$CLIENT_ID_PATTERN\")) | select(.authorizationServicesEnabled == true)")
+done
+
+echo ""
 echo "================================================================"
 echo "SUMMARY REPORT"
 echo "================================================================"
-echo "Realms processed:        $TOTAL_REALMS_PROCESSED"                                                                                                  
-echo "Clients checked:         $TOTAL_CLIENTS_CHECKED"                                                                                                   
-echo "----------------------------------------------------------------"                                                                                  
-if [[ "$DRY_RUN" == "true" ]]; then                                                                                                                      
-  echo "Dead Role Policies found: $TOTAL_DEAD_ROLE_POLICIES (NOT deleted)"                                                                               
-  echo "Dead Permissions found:   $TOTAL_DEAD_PERMISSIONS (NOT deleted)"                                                                                 
-else                                                                                                                                                     
-  echo "Dead Role Policies deleted: $TOTAL_DEAD_ROLE_POLICIES"                                                                                           
-  echo "Dead Permissions deleted:   $TOTAL_DEAD_PERMISSIONS"                                                                                             
-fi                                                                                                                                                       
-echo "================================================================"                                                                                  
+echo "Realms processed:        $TOTAL_REALMS_PROCESSED"
+echo "Clients checked:         $TOTAL_CLIENTS_CHECKED"
+echo "----------------------------------------------------------------"
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dead Role Policies found: $TOTAL_DEAD_ROLE_POLICIES (NOT deleted)"
+  echo "Dead Permissions found:   $TOTAL_DEAD_PERMISSIONS (NOT deleted)"
+else
+  echo "Dead Role Policies deleted: $TOTAL_DEAD_ROLE_POLICIES"
+  echo "Dead Permissions deleted:   $TOTAL_DEAD_PERMISSIONS"
+fi
+echo "================================================================"
 echo "Done."


### PR DESCRIPTION
# fse-cleanup-keycloak-orphaned-records — Changes Summary

## script.sh

### Bug Fixes

1. **jq `Cannot index string with string "id"` on Linux** — Phase 2 `assoc_policies` parsing assumed array elements were always objects. Changed `jq -r '.[].id'` to `jq -r '.[] | if type == "object" then .id else . end'` to handle both object arrays and plain string UUID arrays returned by `.config.applyPolicies`.

2. **Realm not found crashes jq** — Added HTTP status check when fetching clients for a realm. Non-200 responses now produce a clear error message and exit instead of passing error responses to jq.

3. **Token refresh never worked (subshell bug)** — `TOKEN_TIMESTAMP` was set inside `get_token()` which runs in a subshell via `$(get_token)`, so the timestamp never propagated to the parent shell. Moved `TOKEN_TIMESTAMP=$(date +%s)` to the caller after every `TOKEN=$(get_token)` assignment.

### New Features

4. **`TENANT_IDS` parameter** — Added support to specify a comma-separated list of tenant IDs instead of processing all realms. Includes duplicate deduplication while preserving order.

5. **`CLIENT_ID_PATTERN` safe injection via `jq --arg`** — Pattern now passed using `jq --arg pattern "$CLIENT_ID_PATTERN"` instead of direct string interpolation, eliminating risk from special characters.

### Reliability Improvements

6. **`curl_with_retry()` wrapper** — All GET API calls now go through a retry wrapper that checks HTTP status codes, retries up to 3 times on 5xx errors with backoff, and auto-refreshes the token on 401.

7. **`curl_delete_with_retry()` wrapper** — DELETE calls now verify HTTP response status (expects 2xx), retry on 5xx/401, and log warnings on failure instead of silently succeeding.

8. **Token refresh on schedule** — `refresh_token_if_needed()` is called before each realm, client, and paginated chunk fetch. Refreshes every 5 minutes. Both retry wrappers also refresh on 401.

### Performance

9. **O(1) dead-policy lookups** — Added `declare -A dead_role_policy_set` associative array for constant-time membership checks in Phase 2, replacing the O(n) linear scan through the `dead_role_policy_ids` array.
