### PR TITLE
Update remove-unused-authz-objects.sh

### DIFF
--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -382,8 +382,15 @@ process_permissions() {
 
   # Build a hash of dead role policy ids for this client.
   declare -A DEAD
-  while IFS= read -r d; do [[ -n "$d" ]] && DEAD["$d"]=1; done < <(load_dead_roles "$realm" "$client_uuid")
-  if (( ${#DEAD[@]} == 0 )); then
+  local dead_count=0
+  while IFS= read -r d; do
+    if [[ -n "$d" ]]; then
+      DEAD["$d"]=1
+      ((++dead_count))
+    fi
+  done < <(load_dead_roles "$realm" "$client_uuid")
+
+  if (( dead_count == 0 )); then
     log "INFO" "  [$realm/$client_id] no dead role policies — skipping permissions ($ptype)"
     return 0
   fi

--- a/keycloak-scripts/remove-unused-authz-objects.sh
+++ b/keycloak-scripts/remove-unused-authz-objects.sh
@@ -111,6 +111,13 @@ get_token() {
     -d "password=${ADMIN_PASS}" \
     -d 'grant_type=password' \
     -d 'client_id=admin-cli')
+
+  # Validate JSON before parsing - prevents cryptic jq errors
+  if ! echo "$response" | jq -e . >/dev/null 2>&1; then
+    log "ERROR" "Token endpoint returned non-JSON response (first 200 chars): ${response:0:200}"
+    return 1
+  fi
+
   token=$(echo "$response" | jq -r '.access_token // empty')
   if [[ -z "$token" || "$token" == "null" ]]; then
     log "ERROR" "Token request failed: $(echo "$response" | jq -r '.error_description // .error // .')"


### PR DESCRIPTION
This approach:
  1. ✅ Never accesses ${#DEAD[@]} when the array might be empty
  2. ✅ Works reliably with set -u
  3. ✅ Actually faster (no array size calculation needed)