### PR TITLE
[KEYCLOAK-51] Use sessionStorage to ensure `isConsortium` url param is respected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Release Notes
 ## Version `v26.5.5` (in progress)
+* Use sessionStorage to ensure `isConsortium` url param is respected after form submit to allow flags to persist if errors are returned. (KEYCLOAK-51).
 
 ## Version `v26.5.4` (14.05.2026)
 * Use Keycloak supported `jdbc-ping` cache discovery instead of custom JDBC_PING2 XML while preserving authorization cache size tuning via `KC_CACHE_EMBEDDED_AUTHORIZATION_MAX_COUNT`; offline session cache limits can be tuned via `KC_CACHE_EMBEDDED_OFFLINE_SESSIONS_MAX_COUNT` and `KC_CACHE_EMBEDDED_OFFLINE_CLIENT_SESSIONS_MAX_COUNT` (KEYCLOAK-111)

--- a/custom-theme-sso-first/login/login.ftl
+++ b/custom-theme-sso-first/login/login.ftl
@@ -72,14 +72,7 @@
                       <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
                   <a href="${client.baseUrl}" id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
-                  <script type="text/javascript">
-                      const urlParams = new URLSearchParams(window.location.search);
-                      const isConsortium = urlParams.get('isConsortium');
-
-                      if (isConsortium === 'true') {
-                          document.getElementById('return-to-tenant-selection').style.display = 'block';
-                      }
-                  </script>
+                  <script src="${url.resourcesPath}/js/login.js"></script>
             </form>
         </#if>
         </div>

--- a/custom-theme-sso-first/login/resources/js/login.js
+++ b/custom-theme-sso-first/login/resources/js/login.js
@@ -1,0 +1,16 @@
+const IS_CONSORTIUM_KEY = 'isConsortium';
+const urlParams = new URLSearchParams(window.location.search);
+const isConsortium = urlParams.get(IS_CONSORTIUM_KEY);
+const clientId = urlParams.get('client_id');
+
+if (isConsortium === 'true' || sessionStorage.getItem(IS_CONSORTIUM_KEY) === 'true') {
+  // Persist this param value since it gets cleared on form submit.
+  // Session storage ensures other tabs or future browser sessions don't retain value.
+  sessionStorage.setItem(IS_CONSORTIUM_KEY, 'true');
+  document.getElementById('return-to-tenant-selection').style.display = 'block';
+}
+
+handleSubmit = (event) => {
+  login.disabled = true;
+  return true;
+}

--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -6,7 +6,7 @@
     <div id="kc-form">
       <div id="kc-form-wrapper">
         <#if realm.password>
-            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+            <form id="kc-form-login" onsubmit="onSubmit(event)" action="${url.loginAction}" method="post">
                 <#if !usernameHidden??>
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
@@ -72,14 +72,7 @@
                       <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
                   <a href="${client.baseUrl}" id="return-to-tenant-selection" style="display: none;" class="${properties.kcReturnToTenantSelection}">${msg("backToTenantSelection")}</a>
-                  <script type="text/javascript">
-                      const urlParams = new URLSearchParams(window.location.search);
-                      const isConsortium = urlParams.get('isConsortium');
-
-                      if (isConsortium === 'true') {
-                          document.getElementById('return-to-tenant-selection').style.display = 'block';
-                      }
-                  </script>
+                  <script src="${url.resourcesPath}/js/login.js"></script>
             </form>
         </#if>
         </div>

--- a/custom-theme/login/resources/js/login.js
+++ b/custom-theme/login/resources/js/login.js
@@ -1,0 +1,16 @@
+const IS_CONSORTIUM_KEY = 'isConsortium';
+const urlParams = new URLSearchParams(window.location.search);
+const isConsortium = urlParams.get(IS_CONSORTIUM_KEY);
+const clientId = urlParams.get('client_id');
+
+if (isConsortium === 'true' || sessionStorage.getItem(IS_CONSORTIUM_KEY) === 'true') {
+  // Persist this param value since it gets cleared on form submit.
+  // Session storage ensures other tabs or future browser sessions don't retain value.
+  sessionStorage.setItem(IS_CONSORTIUM_KEY, 'true');
+  document.getElementById('return-to-tenant-selection').style.display = 'block';
+}
+
+handleSubmit = (event) => {
+  login.disabled = true;
+  return true;
+}


### PR DESCRIPTION
* This allows `isConsortium` config setting to be accessed after form submit, since that action clears all URL params.
* Extracted inline JS into external files.
* Fixes [KEYCLOAK-51](https://folio-org.atlassian.net/browse/KEYCLOAK-51).

https://github.com/user-attachments/assets/e6a16b79-6e4b-42ae-9048-1948ec3dd140

