### PR TITLE
[KEYCLOAK-51] Correct function call name from `onSubmit` to `handleSubmit` to prevent runtime errors.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Enable `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true` and `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN=true` by default in the published images
   - Upgrade note: hosting providers with custom images not based on the published `folio-keycloak` image must explicitly set `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true` and `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN=true`.
 * Use sessionStorage to ensure `isConsortium` url param is respected after form submit to allow flags to persist if errors are returned. (KEYCLOAK-51).
+* Correct function call name from `onSubmit` to `handleSubmit` to prevent runtime errors. (KEYCLOAK-51).
 
 ## Version `v26.5.4` (14.05.2026)
 * Use Keycloak supported `jdbc-ping` cache discovery instead of custom JDBC_PING2 XML while preserving authorization cache size tuning via `KC_CACHE_EMBEDDED_AUTHORIZATION_MAX_COUNT`; offline session cache limits can be tuned via `KC_CACHE_EMBEDDED_OFFLINE_SESSIONS_MAX_COUNT` and `KC_CACHE_EMBEDDED_OFFLINE_CLIENT_SESSIONS_MAX_COUNT` (KEYCLOAK-111)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Enable `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true` and `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN=true` by default in the published images
   - Upgrade note: hosting providers with custom images not based on the published `folio-keycloak` image must explicitly set `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true` and `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN=true`.
 * Use sessionStorage to ensure `isConsortium` url param is respected after form submit to allow flags to persist if errors are returned. (KEYCLOAK-51).
-* Correct function call name from `onSubmit` to `handleSubmit` to prevent runtime errors. (KEYCLOAK-51).
+* Reverting back to inline JS so use of global var is clearer. (KEYCLOAK-51).
 
 ## Version `v26.5.4` (14.05.2026)
 * Use Keycloak supported `jdbc-ping` cache discovery instead of custom JDBC_PING2 XML while preserving authorization cache size tuning via `KC_CACHE_EMBEDDED_AUTHORIZATION_MAX_COUNT`; offline session cache limits can be tuned via `KC_CACHE_EMBEDDED_OFFLINE_SESSIONS_MAX_COUNT` and `KC_CACHE_EMBEDDED_OFFLINE_CLIENT_SESSIONS_MAX_COUNT` (KEYCLOAK-111)

--- a/custom-theme-sso-first/login/login.ftl
+++ b/custom-theme-sso-first/login/login.ftl
@@ -6,7 +6,7 @@
     <div id="kc-form">
       <div id="kc-form-wrapper">
         <#if realm.password>
-            <form id="kc-form-login" onsubmit="handleSubmit(event)" action="${url.loginAction}" method="post">
+            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <#if !usernameHidden??>
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>

--- a/custom-theme-sso-first/login/login.ftl
+++ b/custom-theme-sso-first/login/login.ftl
@@ -6,7 +6,7 @@
     <div id="kc-form">
       <div id="kc-form-wrapper">
         <#if realm.password>
-            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+            <form id="kc-form-login" onsubmit="handleSubmit(event)" action="${url.loginAction}" method="post">
                 <#if !usernameHidden??>
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>

--- a/custom-theme-sso-first/login/resources/js/login.js
+++ b/custom-theme-sso-first/login/resources/js/login.js
@@ -9,8 +9,3 @@ if (isConsortium === 'true' || sessionStorage.getItem(IS_CONSORTIUM_KEY) === 'tr
   sessionStorage.setItem(IS_CONSORTIUM_KEY, 'true');
   document.getElementById('return-to-tenant-selection').style.display = 'block';
 }
-
-handleSubmit = (event) => {
-  login.disabled = true;
-  return true;
-}

--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -6,7 +6,7 @@
     <div id="kc-form">
       <div id="kc-form-wrapper">
         <#if realm.password>
-            <form id="kc-form-login" onsubmit="handleSubmit(event)" action="${url.loginAction}" method="post">
+            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <#if !usernameHidden??>
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>

--- a/custom-theme/login/login.ftl
+++ b/custom-theme/login/login.ftl
@@ -6,7 +6,7 @@
     <div id="kc-form">
       <div id="kc-form-wrapper">
         <#if realm.password>
-            <form id="kc-form-login" onsubmit="onSubmit(event)" action="${url.loginAction}" method="post">
+            <form id="kc-form-login" onsubmit="handleSubmit(event)" action="${url.loginAction}" method="post">
                 <#if !usernameHidden??>
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>

--- a/custom-theme/login/resources/js/login.js
+++ b/custom-theme/login/resources/js/login.js
@@ -9,8 +9,3 @@ if (isConsortium === 'true' || sessionStorage.getItem(IS_CONSORTIUM_KEY) === 'tr
   sessionStorage.setItem(IS_CONSORTIUM_KEY, 'true');
   document.getElementById('return-to-tenant-selection').style.display = 'block';
 }
-
-handleSubmit = (event) => {
-  login.disabled = true;
-  return true;
-}


### PR DESCRIPTION
- Fixes runtime error noted in https://github.com/folio-org/folio-keycloak/pull/103#discussion_r3355074793.
- By using defined function name in JS code, runtime error no longer occurs.
- Also small refactor to use external JS in custom-theme-sso-first/login/login.ftl