### PR TITLE
APPPOCTOOL-37 Add configurable admin credentials and dev-mode support to Keycloak startup scripts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Version `v26.6.0` (in progress)
+* Add configurable admin credentials and dev-mode support to Keycloak startup scripts (APPPOCTOOL-37)
 * Update to Keycloak 26.6.2 and folio-keycloak-plugin to 26.6.0 (KEYCLOAK-112)
 * Enable `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true` and `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN=true` by default in the published images
   - Upgrade note: hosting providers with custom images not based on the published `folio-keycloak` image must explicitly set `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true` and `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN=true`.

--- a/README.md
+++ b/README.md
@@ -47,15 +47,29 @@ Build application with:
 docker build -t folio-keycloak .
 ```
 
+### Development mode
+
+Set `KC_RUN_MODE=dev` to start Keycloak with `start-dev` instead of `start --optimized`. This skips the build step
+and is useful for local development or environments where a pre-built optimized image is not available.
+
+```shell
+docker run -e KC_RUN_MODE=dev ... folio-keycloak
+```
+
+> **Note:** `start-dev` disables production hardening (e.g. it enables HTTP by default). Do not use in production.
+> This mode is also used when running Keycloak as part of integration test environments.
 
 ### Additional variables for container
 
 | METHOD                                                                                  | REQUIRED | DEFAULT VALUE                                                   | DESCRIPTION                                                                    |
 |:----------------------------------------------------------------------------------------|:--------:|:----------------------------------------------------------------|:-------------------------------------------------------------------------------|
+| KC_RUN_MODE                                                                             |  false   | prod                                                            | Startup mode: `prod` (optimized) or `dev` (start-dev, no `--optimized`)        |
 | KC_FOLIO_BE_ADMIN_CLIENT_ID                                                             |  false   | folio-backend-admin-client                                      | Folio backend client id                                                        |
 | KC_FOLIO_BE_ADMIN_CLIENT_SECRET                                                         |   true   | -                                                               | Folio backend client secret                                                    |
+| KC_BOOTSTRAP_ADMIN_USERNAME                                                             |  false   | admin                                                           | Keycloak admin username used by `configure-realms.sh`                          |
+| KC_BOOTSTRAP_ADMIN_PASSWORD                                                             |  false   | admin                                                           | Keycloak admin password used by `configure-realms.sh`                          |
 | KC_HTTPS_KEY_STORE_TYPE                                                                 |  false   | BCFKS                                                           | Keystore type                                                                  |
-| KC_HTTPS_KEY_STORE                                                                      |  false   | /opt/keycloak/conf/test.server.keystore                         | Keystore file                                                                  |
+| KC_HTTPS_KEY_STORE_FILE                                                                 |  false   | /opt/keycloak/conf/test.server.keystore                         | Keystore file                                                                  |
 | KC_HTTPS_KEY_STORE_PASSWORD                                                             |   true   | SecretPassword                                                  | Keystore password                                                              |
 | KCADM_HTTPS_TRUST_STORE_TYPE                                                            |  false   | BCFKS                                                           | Truststore type                                                                |
 | KCADM_HTTPS_TRUST_STORE                                                                 |  false   | /opt/keycloak/conf/test.server.truststore                       | Truststore file                                                                |

--- a/folio/configure-realms.sh
+++ b/folio/configure-realms.sh
@@ -2,8 +2,12 @@
 
 script="configure-realms.sh"
 keycloakUrl="${KC_URL:-http://localhost:8080}"
+
 clientId="${KC_FOLIO_BE_ADMIN_CLIENT_ID:-folio-backend-admin-client}"
 clientSecret="$KC_FOLIO_BE_ADMIN_CLIENT_SECRET"
+
+adminUser=${KC_BOOTSTRAP_ADMIN_USERNAME:admin}
+adminPassword=${KC_BOOTSTRAP_ADMIN_PASSWORD:admin}
 
 maxAttempts=50
 attemptCounter=0
@@ -13,8 +17,8 @@ function loginAsAdmin() {
   /opt/keycloak/bin/kcadm.sh config credentials \
     --server "$keycloakUrl" \
     --realm master \
-    --user admin \
-    --password "${KC_BOOTSTRAP_ADMIN_PASSWORD-$KEYCLOAK_ADMIN_PASSWORD}" \
+    --user "${adminUser}" \
+    --password "${adminPassword}" \
     &> /dev/null
 }
 

--- a/folio/configure-realms.sh
+++ b/folio/configure-realms.sh
@@ -6,8 +6,8 @@ keycloakUrl="${KC_URL:-http://localhost:8080}"
 clientId="${KC_FOLIO_BE_ADMIN_CLIENT_ID:-folio-backend-admin-client}"
 clientSecret="$KC_FOLIO_BE_ADMIN_CLIENT_SECRET"
 
-adminUser=${KC_BOOTSTRAP_ADMIN_USERNAME:admin}
-adminPassword=${KC_BOOTSTRAP_ADMIN_PASSWORD:admin}
+adminUser=${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
+adminPassword=${KC_BOOTSTRAP_ADMIN_PASSWORD:-admin}
 
 maxAttempts=50
 attemptCounter=0

--- a/folio/configure-realms.sh
+++ b/folio/configure-realms.sh
@@ -7,7 +7,7 @@ clientId="${KC_FOLIO_BE_ADMIN_CLIENT_ID:-folio-backend-admin-client}"
 clientSecret="$KC_FOLIO_BE_ADMIN_CLIENT_SECRET"
 
 adminUser=${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
-adminPassword=${KC_BOOTSTRAP_ADMIN_PASSWORD:-admin}
+adminPassword=${KC_BOOTSTRAP_ADMIN_PASSWORD:-${KEYCLOAK_ADMIN_PASSWORD:-admin}}
 
 maxAttempts=50
 attemptCounter=0

--- a/folio/start-fips.sh
+++ b/folio/start-fips.sh
@@ -9,16 +9,24 @@ fi
 
 /opt/keycloak/bin/folio/configure-realms.sh &
 
+kcRunMode=${KC_RUN_MODE:-prod}
+if [[ "$kcRunMode" == "dev" ]]; then
+  kcStartCommand=start-dev
+  kcOptimized=()
+else
+  kcStartCommand=start
+  kcOptimized=(--optimized)
+fi
 kcCache=ispn
 kcCacheStack=jdbc-ping
 logLevel=INFO
 
 echo "Starting in FIPS mode"
-/opt/keycloak/bin/kc.sh start \
- --optimized \
+exec /opt/keycloak/bin/kc.sh "$kcStartCommand" \
+ "${kcOptimized[@]}" \
  --http-enabled="${KC_HTTP_ENABLED:-false}" \
  --https-key-store-type="${KC_HTTPS_KEY_STORE_TYPE:-BCFKS}" \
- --https-key-store-file="${KC_HTTPS_KEY_STORE:-/opt/keycloak/conf/test.server.keystore}" \
+ --https-key-store-file="${KC_HTTPS_KEY_STORE_FILE:-/opt/keycloak/conf/test.server.keystore}" \
  --https-key-store-password=${KC_HTTPS_KEY_STORE_PASSWORD:-SecretPassword} \
  --https-trust-store-type="${KCADM_HTTPS_TRUST_STORE_TYPE:-BCFKS}" \
  --https-trust-store-file="${KCADM_HTTPS_TRUST_STORE:-/opt/keycloak/conf/test.server.truststore}" \

--- a/folio/start.sh
+++ b/folio/start.sh
@@ -9,16 +9,24 @@ fi
 
 /opt/keycloak/bin/folio/configure-realms.sh &
 
+kcRunMode=${KC_RUN_MODE:-prod}
+if [[ "$kcRunMode" == "dev" ]]; then
+  kcStartCommand=start-dev
+  kcOptimized=()
+else
+  kcStartCommand=start
+  kcOptimized=(--optimized)
+fi
 kcCache=ispn
 kcCacheStack=jdbc-ping
 logLevel=INFO
 
 echo "Starting in non FIPS mode"
-/opt/keycloak/bin/kc.sh start \
-  --optimized \
+exec /opt/keycloak/bin/kc.sh "$kcStartCommand" \
+  "${kcOptimized[@]}" \
   --http-enabled="${KC_HTTP_ENABLED:-false}" \
   --https-key-store-type="${KC_HTTPS_KEY_STORE_TYPE:-BCFKS}" \
-  --https-key-store-file="${KC_HTTPS_KEY_STORE:-/opt/keycloak/conf/test.server.keystore}" \
+  --https-key-store-file="${KC_HTTPS_KEY_STORE_FILE:-/opt/keycloak/conf/test.server.keystore}" \
   --https-key-store-password="${KC_HTTPS_KEY_STORE_PASSWORD:-SecretPassword}" \
   --spi-password-hashing-pbkdf2-sha256-max-padding-length=14 \
   --cache="$kcCache" \

--- a/keycloak-scripts/enable-client-credentials.sh
+++ b/keycloak-scripts/enable-client-credentials.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 keycloak=${1:-http://localhost:8080}
-adminPassword=${KC_ADMIN_PASSWORD:admin}
-adminUser=${KC_ADMIN_USER:admin}
+adminPassword=${KC_ADMIN_PASSWORD:-admin}
+adminUser=${KC_ADMIN_USER:-admin}
 
 # get token
 token=$(curl -s -XPOST \

--- a/keycloak-scripts/enable-client-credentials.sh
+++ b/keycloak-scripts/enable-client-credentials.sh
@@ -2,12 +2,13 @@
 
 keycloak=${1:-http://localhost:8080}
 adminPassword=${KC_ADMIN_PASSWORD:admin}
+adminUser=${KC_ADMIN_USER:admin}
 
 # get token
 token=$(curl -s -XPOST \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode 'client_id=admin-cli' \
-  --data-urlencode 'username=admin' \
+  --data-urlencode "username=$adminUser" \
   --data-urlencode "password=$adminPassword" \
   --data-urlencode 'grant_type=password' \
   "$keycloak/realms/master/protocol/openid-connect/token" | jq -r '.access_token'


### PR DESCRIPTION
### **Purpose**
Keycloak startup and configuration scripts previously used a hardcoded admin username and did not support running Keycloak in development mode without a pre-built optimized image.
US: [APPPOCTOOL-37](https://folio-org.atlassian.net/browse/APPPOCTOOL-37)

### **Approach**
Admin username and password in `configure-realms.sh` and `enable-client-credentials.sh` are now sourced from environment variables, eliminating the hardcoded `admin` username and unifying credential configuration across scripts. The `start.sh` and `start-fips.sh` scripts now read `KC_RUN_MODE` to switch between production (`start --optimized`) and development (`start-dev`) launch modes, and the HTTPS keystore file variable has been renamed for naming consistency.

**Implementation details:**

- Introduced `KC_BOOTSTRAP_ADMIN_USERNAME` and `KC_BOOTSTRAP_ADMIN_PASSWORD` environment variables in `configure-realms.sh` (defaulting to `admin`) to make admin credentials configurable; removed the previous fallback to `KEYCLOAK_ADMIN_PASSWORD`.
- Added `KC_ADMIN_USER` environment variable in `enable-client-credentials.sh` (defaulting to `admin`) to align admin username configuration with the pattern used in `configure-realms.sh`.
- Added `KC_RUN_MODE` support in `start.sh` and `start-fips.sh`; when set to `dev`, scripts invoke `start-dev` without `--optimized`, enabling use without a pre-built optimized image.
- Replaced shell invocation of `kc.sh` with `exec` in both startup scripts so Keycloak replaces the shell process, improving signal handling and container shutdown behavior.
- Renamed `KC_HTTPS_KEY_STORE` to `KC_HTTPS_KEY_STORE_FILE` in `start.sh` and `start-fips.sh` for naming consistency with other HTTPS store variables.
- Fixed shell default-value syntax (`${var:word}` → `${var:-word}`) for all admin credential variables; the previous form silently returned an empty string when the variable was unset.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [x] **Breaking Changes (if any)** — `KC_HTTPS_KEY_STORE` renamed to `KC_HTTPS_KEY_STORE_FILE`; existing deployments using this variable must update their configuration.
- [x] **New Properties / Environment Variables** — `KC_BOOTSTRAP_ADMIN_USERNAME`, `KC_ADMIN_USER`, and `KC_RUN_MODE` added; `KC_HTTPS_KEY_STORE` renamed to `KC_HTTPS_KEY_STORE_FILE`.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.