### PR TITLE
KEYCLOAK-125: add script to repair role and policy UUIDs after realm migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Reverting back to inline JS so use of global var is clearer. (KEYCLOAK-51).
 * Update to Keycloak 26.6.3 and folio-keycloak-plugin to 26.6.1 (KEYCLOAK-116)
 * Add consistent error message for case where user account is disabled and credentials are entered correctly (KEYCLOAK-101)
+* `repair-role-policy-uuids.sh` now matches policies by referenced entity instead of by name, repairing user policies (not just role policies) and their permissions, with honest per-class reporting of anything it cannot synchronise. Keycloak is rewritten before the FOLIO transaction commits, which makes an interrupted run safe to simply re-run — no recovery mode or saved state (KEYCLOAK-125)
 
 ## Version `v26.5.4` (14.05.2026)
 * Use Keycloak supported `jdbc-ping` cache discovery instead of custom JDBC_PING2 XML while preserving authorization cache size tuning via `KC_CACHE_EMBEDDED_AUTHORIZATION_MAX_COUNT`; offline session cache limits can be tuned via `KC_CACHE_EMBEDDED_OFFLINE_SESSIONS_MAX_COUNT` and `KC_CACHE_EMBEDDED_OFFLINE_CLIENT_SESSIONS_MAX_COUNT` (KEYCLOAK-111)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This table documents tested compatibility between folio-keycloak and FOLIO relea
 tested. Combinations not explicitly stated may work, but are not guaranteed.
 
 > **Note:**  
-> If you are a product or have tested a FOLIO Keycloak version with a specific FOLIO release, please contribute your findings. If you can confirm compatibility or incompatibility, create a PR in this project to update the documentation. Include evidence or explanations for your results to help keep the compatibility table current.  
+> If you are a product or have tested a FOLIO Keycloak version with a specific FOLIO release, please contribute your
+> findings. If you can confirm compatibility or incompatibility, create a PR in this project to update the documentation.
+> Include evidence or explanations for your results to help keep the compatibility table current.  
 > _We appreciate your contributions!_
 
 | folio-keycloak | Compatible With             | Not Compatible With         |
@@ -82,7 +84,10 @@ docker run -e KC_RUN_MODE=dev ... folio-keycloak
 | KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN     |  false   | true                                                            | Allow UserInfo with lightweight access tokens. Should be set as `true`         |
 
 #### Note – Temporary setting required to retain Keycloak 26.5.7 OIDC behavior expected by FOLIO.
-The published `folio-keycloak` image defaults the following variables to `true`. This retains the Keycloak 26.5.7 OIDC behavior expected by FOLIO.
+
+The published `folio-keycloak` image defaults the following variables to `true`. This retains the Keycloak 26.5.7 OIDC
+behavior expected by FOLIO.
+
 - `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK`
 - `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN`
 
@@ -226,10 +231,15 @@ Script to identify and remove Keycloak Authorization policies and permissions th
 ### What the Script Does
 
 - **Identifies Dead Role Policies:** Finds policies of type 'role' where all referenced roles have been deleted.
-- **Identifies Dead Permissions:** Finds 'scope' or 'resource' permissions that exclusively use the identified dead policies.
-- **Streaming & Resumable:** Streams each page of policies/permissions and deletes orphans immediately, never holding the full ID set in memory. Persists progress in a state directory so a crash or restart can resume from the last committed offset.
-- **High Performance:** Pre-loads all realm role IDs into an in-memory hash, drastically speeding up lookups (often 50-200x on large realms), and uses single-pass `jq` filters per page.
-- **Parallel Deletions:** Deletes in configurable batches with bounded parallelism (`xargs -P`) and optional throttling between batches.
+- **Identifies Dead Permissions:** Finds 'scope' or 'resource' permissions that exclusively use the identified dead
+  policies.
+- **Streaming & Resumable:** Streams each page of policies/permissions and deletes orphans immediately, never holding
+  the full ID set in memory. Persists progress in a state directory so a crash or restart can resume from the last
+  committed offset.
+- **High Performance:** Pre-loads all realm role IDs into an in-memory hash, drastically speeding up lookups (often
+  50-200x on large realms), and uses single-pass `jq` filters per page.
+- **Parallel Deletions:** Deletes in configurable batches with bounded parallelism (`xargs -P`) and optional throttling
+  between batches.
 - **Dry-Run Mode:** By default, it only previews what would be deleted without making any changes.
 - **Summary Report:** Provides a detailed count of processed realms, checked clients, and found/deleted resources.
 
@@ -265,43 +275,51 @@ export LOG_FILE="./.kc-cleanup-state/run.log" # Append structured log here
 ### Examples
 
 **Dry-run, all realms, default settings:**
+
 ```bash
 DRY_RUN=true ./keycloak-scripts/remove-unused-authz-objects.sh admin <pwd>
 ```
 
 **One tenant, real deletions, more parallelism:**
+
 ```bash
 DRY_RUN=false TENANT_IDS=acme PARALLEL_DELETES=8 BATCH_SIZE=100 \
   ./keycloak-scripts/remove-unused-authz-objects.sh admin <pwd>
 ```
 
 **Multiple tenants, gentle on Keycloak:**
+
 ```bash
 DRY_RUN=false TENANT_IDS=acme,globex,initech PARALLEL_DELETES=2 BATCH_SLEEP_MS=250 \
   ./keycloak-scripts/remove-unused-authz-objects.sh admin <pwd>
 ```
 
 **Resume after a Keycloak restart (same command, same STATE_DIR):**
+
 ```bash
 DRY_RUN=false TENANT_IDS=acme ./keycloak-scripts/remove-unused-authz-objects.sh admin <pwd>
 ```
 
 **Start over (wipes previous state):**
+
 ```bash
 RESET_STATE=true DRY_RUN=true ./keycloak-scripts/remove-unused-authz-objects.sh admin <pwd>
 ```
 
 ### Resume Behavior
 
-The script saves its execution state to a `.kc-cleanup-state/` directory by default. This allows the script to safely resume where it left off in the event of a crash, Keycloak restart, or early termination (SIGTERM). 
+The script saves its execution state to a `.kc-cleanup-state/` directory by default. This allows the script to safely
+resume where it left off in the event of a crash, Keycloak restart, or early termination (SIGTERM).
 
 The state layout includes:
+
 - `run.log`: A structured append-only log.
 - `realms.done`: Tracks fully processed realms.
 - `clients.done`: Tracks fully processed clients within a realm.
 - `<client_uuid>.cursor`: Tracks the exact phase and offset for in-progress clients.
 
-A re-run with the same `STATE_DIR` skips everything already marked as "done" and continues the in-progress client from its last cursor. To start completely fresh, use `RESET_STATE=true`.
+A re-run with the same `STATE_DIR` skips everything already marked as "done" and continues the in-progress client from
+its last cursor. To start completely fresh, use `RESET_STATE=true`.
 
 ## Online Realm Migration [migrate-realm.sh](keycloak-scripts/migrate-realm.sh)
 
@@ -309,12 +327,18 @@ Script for online cluster-to-cluster Keycloak realm migration using the Admin RE
 
 ### What the Script Does
 
-- **Atomic Realm Creation:** Imports realm configuration (login, tokens, themes, etc.), roles, groups, clients (with full authorization settings), authentication flows, and identity providers in a single POST request.
-- **Batched User Import:** Migrates users separately using the `partialImport` API in configurable batches to avoid body-size limits and ensure reliability.
-- **Pre-flight Validation:** Verifies the destination realm doesn't exist, checks for required signing keys to maintain token validity, and summarizes authorization settings coverage.
-- **Cache Verification:** Optionally verifies that the newly created realm is visible across all nodes in the destination cluster to ensure proper JGroups propagation.
-- **Post-Import Spot-checks:** Performs deep validation of authorization objects (resources, policies, permissions) and user counts to ensure migration integrity.
-- **Resumable:** If user import fails, it can be resumed by re-running the script; it uses the `FAIL` strategy for `partialImport` to remain idempotent.
+- **Atomic Realm Creation:** Imports realm configuration (login, tokens, themes, etc.), roles, groups, clients (with
+  full authorization settings), authentication flows, and identity providers in a single POST request.
+- **Batched User Import:** Migrates users separately using the `partialImport` API in configurable batches to avoid
+  body-size limits and ensure reliability.
+- **Pre-flight Validation:** Verifies the destination realm doesn't exist, checks for required signing keys to maintain
+  token validity, and summarizes authorization settings coverage.
+- **Cache Verification:** Optionally verifies that the newly created realm is visible across all nodes in the
+  destination cluster to ensure proper JGroups propagation.
+- **Post-Import Spot-checks:** Performs deep validation of authorization objects (resources, policies, permissions) and
+  user counts to ensure migration integrity.
+- **Resumable:** If user import fails, it can be resumed by re-running the script; it uses the `FAIL` strategy for
+  `partialImport` to remain idempotent.
 
 ### Requirements
 
@@ -348,54 +372,57 @@ export USER_BATCH_SIZE=1000
 
 ### Exit Codes
 
-| Code | Meaning |
-|:-----|:--------|
-| 0    | Success |
-| 1    | Pre-flight failure (no writes performed) |
+| Code | Meaning                                                        |
+|:-----|:---------------------------------------------------------------|
+| 0    | Success                                                        |
+| 1    | Pre-flight failure (no writes performed)                       |
 | 2    | Failure during realm creation (realm may need manual deletion) |
-| 3    | Failure during user import (realm exists, safe to resume) |
-| 4    | Cache verification failure (investigate JGroups) |
-| 5    | Post-import authorization spot-check failed |
+| 3    | Failure during user import (realm exists, safe to resume)      |
+| 4    | Cache verification failure (investigate JGroups)               |
+| 5    | Post-import authorization spot-check failed                    |
 
 ### Notes
 
 - **Zero Downtime:** Designed to migrate realms to a running cluster without requiring a restart.
 - **Sessions:** User sessions and offline tokens are **NOT** migrated. Users will need to re-authenticate.
-- **Signing Keys:** The script ensures signing keys are imported so that refresh tokens from the source cluster remain valid (if the client is already configured to trust them).
-- **Fine-Grained Admin Permissions:** If using FGAP V2, ensure the feature is enabled on both source and destination clusters.
+- **Signing Keys:** The script ensures signing keys are imported so that refresh tokens from the source cluster remain
+  valid (if the client is already configured to trust them).
+- **Fine-Grained Admin Permissions:** If using FGAP V2, ensure the feature is enabled on both source and destination
+  clusters.
 
 ## Repair Corrupted Tenant Data [repair-policy-uuids.sh](keycloak-scripts/repair-policy-uuids.sh)
 
-This procedure explains how to repair corrupted tenant data after a Keycloak realm migration by re-aligning policy UUIDs between Keycloak and FOLIO.
+This procedure explains how to repair corrupted tenant data after a Keycloak realm migration by re-aligning policy UUIDs
+between Keycloak and FOLIO.
 
 ### Problem Description
 
-After realm migration, some resource identifiers (UUIDs) in Keycloak change. However, FOLIO (`mod-roles-keycloak`) may still reference the old UUIDs.
+After realm migration, some resource identifiers (UUIDs) in Keycloak change. However, FOLIO (`mod-roles-keycloak`) may
+still reference the old UUIDs.
 
 This leads to:
+
 - Broken references between FOLIO and Keycloak.
 - Missing resources when resolving policies.
 - Inability to manage roles and permissions correctly.
 
 To resolve this, we must synchronize the correct UUIDs from Keycloak into the FOLIO database.
 
-Because PostgreSQL does not support cross-database joins, the required data must be exported from Keycloak and imported into FOLIO.
+Because PostgreSQL does not support cross-database joins, the required data must be exported from Keycloak and imported
+into FOLIO.
 
 ### Step 1: Export Resource Data from Keycloak
 
 Run the following query on the Keycloak database:
 
 ```sql
-SELECT 
-    rsp.id AS id,
-    rsp.name AS name
+SELECT rsp.id   AS id,
+       rsp.name AS name
 FROM resource_server_policy rsp
-JOIN client c ON rsp.resource_server_id = c.id
-WHERE c.realm_id = (
-    SELECT id 
-    FROM realm r 
-    WHERE r.name = '$tenantName'
-);
+         JOIN client c ON rsp.resource_server_id = c.id
+WHERE c.realm_id = (SELECT id
+                    FROM realm r
+                    WHERE r.name = '$tenantName');
 ```
 
 Replace `$tenantName` with the actual tenant name.
@@ -403,16 +430,16 @@ Replace `$tenantName` with the actual tenant name.
 **Export to CSV (psql):**
 
 ```sql
-\copy (
-    SELECT 
-        rsp.id,
-        rsp.name
-    FROM resource_server_policy rsp
-    JOIN client c ON rsp.resource_server_id = c.id
-    WHERE c.realm_id = (
-        SELECT id FROM realm r WHERE r.name = '$tenantName'
-    )
-) TO '/tmp/keycloak_policies.csv' WITH (FORMAT csv, HEADER true);
+\copy
+(
+SELECT rsp.id,
+       rsp.name
+FROM resource_server_policy rsp
+         JOIN client c ON rsp.resource_server_id = c.id
+WHERE c.realm_id = (SELECT id
+                    FROM realm r
+                    WHERE r.name = '$tenantName') ) TO '/tmp/keycloak_policies.csv'
+WITH (FORMAT csv, HEADER true);
 ```
 
 ### Step 2: Import Data into FOLIO Database
@@ -420,9 +447,10 @@ Replace `$tenantName` with the actual tenant name.
 Connect to the FOLIO database and create a staging table:
 
 ```sql
-CREATE TABLE names_csv_staging (
+CREATE TABLE names_csv_staging
+(
     name text,
-    id uuid
+    id   uuid
 );
 ```
 
@@ -430,8 +458,8 @@ CREATE TABLE names_csv_staging (
 
 ```sql
 COPY names_csv_staging (id, name)
-FROM '/tmp/keycloak_policies.csv'
-WITH (FORMAT csv, HEADER true);
+    FROM '/tmp/keycloak_policies.csv'
+    WITH (FORMAT csv, HEADER true);
 ```
 
 ### Step 3: Synchronize UUIDs in FOLIO
@@ -442,54 +470,54 @@ Execute the following script in a single transaction:
 BEGIN;
 
 -- 1) Backup role assignments
-CREATE TEMP TABLE policy_roles_backup AS
-SELECT
-    pr.role_id,
-    pr.required,
-    p.name AS policy_name
+CREATE
+TEMP TABLE policy_roles_backup AS
+SELECT pr.role_id,
+       pr.required,
+       p.name AS policy_name
 FROM $tenantName_mod_roles_keycloak.policy_roles pr
-JOIN $tenantName_mod_roles_keycloak."policy" p
-    ON pr.policy_id = p.id;
+         JOIN $tenantName_mod_roles_keycloak."policy" p
+              ON pr.policy_id = p.id;
 
 -- 2) Backup user assignments
-CREATE TEMP TABLE policy_users_backup AS
-SELECT
-    pu.user_id,
-    p.name AS policy_name
+CREATE
+TEMP TABLE policy_users_backup AS
+SELECT pu.user_id,
+       p.name AS policy_name
 FROM $tenantName_mod_roles_keycloak.policy_users pu
-JOIN $tenantName_mod_roles_keycloak."policy" p
-    ON pu.policy_id = p.id;
+         JOIN $tenantName_mod_roles_keycloak."policy" p
+              ON pu.policy_id = p.id;
 
 -- 3) Remove existing assignments
-DELETE FROM $tenantName_mod_roles_keycloak.policy_roles;
-DELETE FROM $tenantName_mod_roles_keycloak.policy_users;
+DELETE
+FROM $tenantName_mod_roles_keycloak.policy_roles;
+DELETE
+FROM $tenantName_mod_roles_keycloak.policy_users;
 
 -- 4) Update policy UUIDs from staging table
 UPDATE $tenantName_mod_roles_keycloak."policy" p
-SET id = c.id
-FROM names_csv_staging c
+SET id = c.id FROM names_csv_staging c
 WHERE p.name = c.name
   AND c.id IS NOT NULL
-  AND p.id IS DISTINCT FROM c.id;
+  AND p.id IS DISTINCT
+FROM c.id;
 
 -- 5) Restore role assignments
 INSERT INTO $tenantName_mod_roles_keycloak.policy_roles (policy_id, role_id, required)
-SELECT
-    p.id,
-    b.role_id,
-    b.required
+SELECT p.id,
+       b.role_id,
+       b.required
 FROM policy_roles_backup b
-JOIN $tenantName_mod_roles_keycloak."policy" p
-    ON p.name = b.policy_name;
+         JOIN $tenantName_mod_roles_keycloak."policy" p
+              ON p.name = b.policy_name;
 
 -- 6) Restore user assignments
 INSERT INTO $tenantName_mod_roles_keycloak.policy_users (policy_id, user_id)
-SELECT
-    p.id,
-    b.user_id
+SELECT p.id,
+       b.user_id
 FROM policy_users_backup b
-JOIN $tenantName_mod_roles_keycloak."policy" p
-    ON p.name = b.policy_name;
+         JOIN $tenantName_mod_roles_keycloak."policy" p
+              ON p.name = b.policy_name;
 
 COMMIT;
 ```
@@ -517,3 +545,90 @@ export TENANT="diku"
 
 ./keycloak-scripts/repair-policy-uuids.sh
 ```
+
+## Repair Corrupted Role and Policy UUIDs [repair-role-policy-uuids.sh](keycloak-scripts/repair-role-policy-uuids.sh)
+
+`repair-policy-uuids.sh` (above) only fixes policy UUIDs. A same-cluster realm migration also hands roles brand-new Keycloak UUIDs, and `mod-roles-keycloak` stores that UUID as `role.id`. Every stored reference then points at the old id, so editing or deleting a role returns `404` from Keycloak. This script re-aligns both. Roles and policies must be fixed together, in one transaction: a role's UUID is embedded in its policy's name on both sides, so the ids have to be re-mapped before any name is rewritten.
+
+**How it works.** Roles and policies are matched between FOLIO and Keycloak *by name* (ids no longer line up). The script:
+
+1. Snapshots the current Keycloak role/policy ids and builds an old→new map, keyed by name.
+2. In a single FOLIO transaction, fixes `role.id` and `policy.id` and every row that points at them — `user_role` (role assignments), `role_capability`, `role_capability_set`, `role_loadable`, `role_loadable_permission`, `policy_roles`, `policy_users` — then rewrites the old id out of `policy.name` / `policy.description`.
+3. Rewrites the old id out of Keycloak's `resource_server_policy` names and, if stale, the role wiring in `policy_config`.
+
+With `DRY_RUN=true` it runs step 2 and rolls it back, prints what it would change, and skips Keycloak entirely. Re-run the script after a real run — a clean repair reports `Nothing to do`.
+
+### Running it
+
+Back up the schema first, then dry-run before the real thing:
+
+```bash
+export KC_DB_URL="postgresql://user:pass@host:5432/keycloak"
+export FOLIO_DB_URL="postgresql://user:pass@host:5432/folio"
+export TENANT="diku"
+
+pg_dump "$FOLIO_DB_URL" -n "${TENANT}_mod_roles_keycloak" > roles_backup.sql
+
+DRY_RUN=true ./keycloak-scripts/repair-role-policy-uuids.sh   # report only, nothing committed
+./keycloak-scripts/repair-role-policy-uuids.sh                # apply
+```
+
+| Variable       | Default                                 | Purpose                                                      |
+|----------------|-----------------------------------------|--------------------------------------------------------------|
+| `KC_DB_URL`    | *(required)*                            | Keycloak DB connection URL                                   |
+| `FOLIO_DB_URL` | *(required)*                            | FOLIO DB connection URL                                      |
+| `TENANT`       | *(required)*                            | Tenant / realm name                                          |
+| `DRY_RUN`      | `false`                                 | Run the FOLIO transaction, roll it back, print a report      |
+| `FORCE`        | `false`                                 | Skip roles that exist in FOLIO but not Keycloak (else abort) |
+| `WORK_DIR`     | `/tmp/repair-role-policy-uuids-$TENANT` | KC exports and the recovery map CSV                          |
+
+### Good to know
+
+- The FOLIO transaction takes `EXCLUSIVE` locks on the nine affected tables — readers are fine, concurrent writers wait — and a dry run takes them too. Between the FOLIO commit and the Keycloak rewrite, role management is briefly inconsistent.
+- The script aborts before writing anything if a table's columns don't match what it expects, so a schema change in a newer `mod-roles-keycloak` can't corrupt data silently.
+- A dry run still creates and drops its staging tables in the DB (each `psql` call is a separate session); it never touches the tenant's own tables.
+- `WORK_DIR` keeps the old→new map CSV on purpose — it's what you recover from if the run dies after the FOLIO commit but before Keycloak (see below). Delete it once roles are editable again.
+- Keycloak caches authorization data in memory, so after a real run either roll-restart the Keycloak nodes or call `POST /admin/realms/{tenant}/clear-realm-cache` (clears the authz cache cluster-wide). `mod-roles-keycloak` doesn't cache role ids, but its config caches have a 3600s TTL — restart it or wait out the TTL before managing the repaired roles.
+
+### Recovering from a half-finished run
+
+If the FOLIO transaction commits but the Keycloak rewrite fails, a re-run sees ids already matching, computes an empty map, and stops — pointing you here. Finish the Keycloak side by hand from the map CSV the failed run left in `WORK_DIR`:
+
+```bash
+psql "$KC_DB_URL" -v ON_ERROR_STOP=1 \
+  -c "DROP TABLE IF EXISTS role_uuid_map_staging;
+      CREATE TABLE role_uuid_map_staging (old_id uuid, new_id uuid, name text);" \
+  -c "\copy role_uuid_map_staging FROM '/tmp/repair-role-policy-uuids-${TENANT}/role_id_map.csv' WITH (FORMAT csv, HEADER true)"
+
+psql "$KC_DB_URL" -v ON_ERROR_STOP=1 <<SQL
+BEGIN;
+UPDATE resource_server_policy rsp
+SET name = replace(rsp.name, m.old_id::text, m.new_id::text)
+FROM role_uuid_map_staging m
+WHERE rsp.resource_server_id IN (
+        SELECT c.id FROM client c WHERE c.realm_id = (SELECT id FROM realm WHERE name = '${TENANT}'))
+  AND strpos(rsp.name, m.old_id::text) > 0;
+DO \$\$
+DECLARE n bigint;
+BEGIN
+  LOOP
+    UPDATE policy_config pc
+    SET value = replace(pc.value, m.old_id::text, m.new_id::text)
+    FROM role_uuid_map_staging m
+    WHERE pc.name = 'roles' AND strpos(pc.value, m.old_id::text) > 0
+      AND pc.policy_id IN (
+        SELECT rsp.id FROM resource_server_policy rsp
+        JOIN client c ON rsp.resource_server_id = c.id
+        WHERE c.realm_id = (SELECT id FROM realm WHERE name = '${TENANT}'));
+    GET DIAGNOSTICS n = ROW_COUNT;
+    EXIT WHEN n = 0;
+  END LOOP;
+END
+\$\$;
+COMMIT;
+SQL
+
+psql "$KC_DB_URL" -c "DROP TABLE role_uuid_map_staging;"
+```
+
+Then re-run the script — it must report `Nothing to do`, and invalidate the Keycloak cache as above.

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ export TENANT="diku"
 
 ## Repair Corrupted Role and Policy UUIDs [repair-role-policy-uuids.sh](keycloak-scripts/repair-role-policy-uuids.sh)
 
-`repair-policy-uuids.sh` (above) only fixes policy UUIDs. A same-cluster realm migration also hands roles brand-new Keycloak UUIDs, and `mod-roles-keycloak` stores that UUID as `role.id`. Every stored reference then points at the old id, so editing or deleting a role returns `404` from Keycloak. This script re-aligns roles **and** policies — both role policies and user policies — in one transaction.
+`repair-policy-uuids.sh` (above) only fixes policy UUIDs. A same-cluster realm migration also hands roles brand-new Keycloak UUIDs, and `mod-roles-keycloak` stores that UUID as `role.id`. Every stored reference then points at the old id, so editing or deleting a role returns `404` from Keycloak. This script re-aligns roles **and** policies — both role policies and user policies. It writes twice, once per database: the Keycloak rewrite commits first, the FOLIO transaction second (see below).
 
 **How it works.** Policies are matched between FOLIO and Keycloak by the **entity they reference**, never by policy name — a policy's name embeds the id of that entity, i.e. the very id that desyncs, so a name join is unreliable. The key is routed by name shape and resolved from the live reference (role *name* and folio *user id* are both stable across the migration, so the key matches even though the ids in the names do not):
 
@@ -567,9 +567,29 @@ The script:
 
 **Keycloak is written before FOLIO, and that order matters.** The two databases share no transaction, so a run can die between the writes. Both id maps are derived from FOLIO's ids still differing from Keycloak's, and the Keycloak step only rewrites name strings — it never changes a Keycloak id. So a run interrupted between the two steps leaves everything the maps are built from intact, and simply running the script again finishes the job. Commit FOLIO first instead and that difference is gone, which is why the reverse order needs a saved map and a resume mode.
 
-Anything it cannot synchronise is reported, never silently skipped: unmatched policies, multi-entity or unresolvable policies (logged under "could not synchronise"), a broken FOLIO↔Keycloak user link (hard abort — the "users were recreated" migration is out of scope, this script has no folio-user-id map source), and any Keycloak name still embedding an id that resolves to no live entity (final `WARN`, exit 3).
+**Best effort, by design.** An anomaly in the *data* does not abort the run: everything that maps 1:1 is repaired, everything that does not is skipped and reported, and the script never deletes a role, policy or permission (it does delete and reinsert child rows inside its own transaction, because the foreign keys are not `ON UPDATE CASCADE` — that is a rewrite, not a removal).
 
-With `DRY_RUN=true` it skips Keycloak entirely, runs the FOLIO transaction and rolls it back, and prints what it would change — nothing is written to either database. Re-run the script after a real run: a clean repair reports `Nothing to repair`.
+It aborts (exit 1) when it cannot work at all — missing variable, realm or schema, or a query it depends on failing — or when a write fails. Each write is a single transaction, but there are two of them in two databases: an abort at or before the Keycloak rewrite leaves both untouched, while an abort in the FOLIO transaction rolls FOLIO back with the Keycloak rewrite already committed. Re-running finishes the job, but do not read exit 1 as "nothing changed".
+
+The report groups the skips by what they ask of you:
+
+| class | meaning | what to do |
+|---|---|---|
+| `ambiguous` | several policies resolve to the same entity, so no id can be assigned deterministically | delete the surplus policy in Keycloak, re-run — the pair then repairs itself |
+| FOLIO-only policy | FOLIO holds a policy Keycloak does not; `mod-roles-keycloak` addresses Keycloak by the FOLIO policy id, so its next update hits a missing object | investigate — usually the realm snapshot predates the FOLIO schema |
+| Keycloak-only policy | no FOLIO counterpart; still enforced, but unmanaged | clean up deliberately, outside this script |
+| `multi` / `unresolved` | the policy references several entities, or none this script can resolve (e.g. a client role) | not repairable by id matching |
+| duplicate Keycloak role names | role name is the only stable key, so the role and its children are left alone | resolve the duplicate name, re-run |
+| roles in FOLIO but not Keycloak | no id to adopt | expected after a partial migration |
+| unknown FOLIO policy type | a type outside `ROLE`/`USER`/`TIME`, which the script cannot key at all | a newer `mod-roles-keycloak` added a type — the script needs teaching |
+| stale user link | `user_role.user_id` values Keycloak does not know as a `user_id` attribute | folio user ids were regenerated; repair user provisioning |
+| collision-excluded map row | rewriting it would land two Keycloak policies on one name, so that id was dropped from the map | resolve the duplicate name in Keycloak; for a **role** id this must be done before the FOLIO commit, because afterwards the old→new mapping no longer exists anywhere |
+
+`ambiguous` is the normal steady state on an environment running `mod-users-keycloak` 3.0.x, where a module system user gets its capabilities by direct user-capability assignment: each change of that user's folio id orphans its `Policy for user: <old id>` and the next assignment creates another one. On 4.x, where system users go through a default role, the class disappears. The report prints the per-key count on both sides — remove the surplus on the side that actually has more than one, since a key duplicated in FOLIO is not fixed by deleting anything in Keycloak.
+
+A stale id that belongs to a policy reported above is expected and is not counted as leftover. Only a stale Keycloak name attributable to no reported skip raises the final `WARN` and exit 3 — which means "written, but not certified clean", not "failed". That check runs after the Keycloak rewrite, so a dry run never reaches it; the equivalent pre-run figure is logged as `unexplained stale KC names`.
+
+With `DRY_RUN=true` (exactly that string — `1` or `yes` performs a **real run**) it skips the Keycloak rewrite, runs the FOLIO transaction and rolls it back, and prints what it would change. No tenant data is written to either database; the run still creates and drops its own staging tables in the FOLIO schema, and reads Keycloak. Re-run the script after a real run: a clean repair reports `Nothing to repair`.
 
 ### Running it
 
@@ -592,14 +612,13 @@ DRY_RUN=true ./keycloak-scripts/repair-role-policy-uuids.sh   # report only, not
 | `FOLIO_DB_URL` | *(required)*                            | FOLIO DB connection URL                                      |
 | `TENANT`       | *(required)*                            | Tenant / realm name                                          |
 | `DRY_RUN`      | `false`                                 | Skip the Keycloak rewrite, run the FOLIO transaction and roll it back, print a report |
-| `FORCE`        | `false`                                 | Skip roles that exist in FOLIO but not Keycloak (else abort) |
-| `WORK_DIR`     | `/tmp/repair-role-policy-uuids-$TENANT` | Scratch space for the CSVs the run passes between the two database connections (`role_id_map.csv`, `user_id_map.csv`, plus the Keycloak exports) |
+| `WORK_DIR`     | `/tmp/repair-role-policy-uuids-$TENANT` | Scratch space for the CSVs the run passes between the two database connections (`role_id_map.csv`, `user_id_map.csv`, `explained_ids.csv`, plus the Keycloak exports) |
 
 ### Good to know
 
 - The FOLIO transaction takes `EXCLUSIVE` locks on the nine affected tables — readers are fine, concurrent writers wait — and a dry run takes them too. Between the Keycloak rewrite and the FOLIO commit, role management is briefly inconsistent.
-- The script aborts before writing anything if a table's columns don't match what it expects, so a schema change in a newer `mod-roles-keycloak` can't corrupt data silently.
-- A dry run still creates and drops its staging tables in the DB (each `psql` call is a separate session); it never touches the tenant's own tables.
+- Child rows are copied with `SELECT *` and reinserted without a column list, so a column added or renamed by a newer `mod-roles-keycloak` flows through untouched. Only the handful of columns the script actually joins and rewrites on is checked, and only their absence aborts the run.
+- A dry run still creates and drops its staging tables in the FOLIO schema (each `psql` call is a separate session, so they cannot be `TEMP`); it never touches the tenant's own tables and never writes to Keycloak at all.
 - The CSVs left in `WORK_DIR` are the run's intermediate state, kept for diagnosis. They are not a recovery mechanism and nothing reads them on a later invocation — delete them whenever you like.
 - Keycloak caches authorization data in memory, so after a real run either roll-restart the Keycloak nodes or call `POST /admin/realms/{tenant}/clear-realm-cache` (clears the authz cache cluster-wide). `mod-roles-keycloak` doesn't cache role ids, but its config caches have a 3600s TTL — restart it or wait out the TTL before managing the repaired roles.
 

--- a/README.md
+++ b/README.md
@@ -548,15 +548,28 @@ export TENANT="diku"
 
 ## Repair Corrupted Role and Policy UUIDs [repair-role-policy-uuids.sh](keycloak-scripts/repair-role-policy-uuids.sh)
 
-`repair-policy-uuids.sh` (above) only fixes policy UUIDs. A same-cluster realm migration also hands roles brand-new Keycloak UUIDs, and `mod-roles-keycloak` stores that UUID as `role.id`. Every stored reference then points at the old id, so editing or deleting a role returns `404` from Keycloak. This script re-aligns both. Roles and policies must be fixed together, in one transaction: a role's UUID is embedded in its policy's name on both sides, so the ids have to be re-mapped before any name is rewritten.
+`repair-policy-uuids.sh` (above) only fixes policy UUIDs. A same-cluster realm migration also hands roles brand-new Keycloak UUIDs, and `mod-roles-keycloak` stores that UUID as `role.id`. Every stored reference then points at the old id, so editing or deleting a role returns `404` from Keycloak. This script re-aligns roles **and** policies — both role policies and user policies — in one transaction.
 
-**How it works.** Roles and policies are matched between FOLIO and Keycloak *by name* (ids no longer line up). The script:
+**How it works.** Policies are matched between FOLIO and Keycloak by the **entity they reference**, never by policy name — a policy's name embeds the id of that entity, i.e. the very id that desyncs, so a name join is unreliable. The key is routed by name shape and resolved from the live reference (role *name* and folio *user id* are both stable across the migration, so the key matches even though the ids in the names do not):
 
-1. Snapshots the current Keycloak role/policy ids and builds an old→new map, keyed by name.
-2. In a single FOLIO transaction, fixes `role.id` and `policy.id` and every row that points at them — `user_role` (role assignments), `role_capability`, `role_capability_set`, `role_loadable`, `role_loadable_permission`, `policy_roles`, `policy_users` — then rewrites the old id out of `policy.name` / `policy.description`.
-3. Rewrites the old id out of Keycloak's `resource_server_policy` names and, if stale, the role wiring in `policy_config`.
+| policy name shape | key | resolved from |
+|---|---|---|
+| `Policy for role: <uuid>` | `role:<role name>` | KC `policy_config['roles']` → `keycloak_role.name`; FOLIO `policy_roles` → `role.name` |
+| `Policy for user: <uuid>` | `user:<folio user id>` | KC `policy_config['users']` → `user_entity` → `user_id` attribute; FOLIO `policy_users.user_id` |
+| anything else | `name:<policy name>` | the literal name (admin-authored / TIME policies) |
 
-With `DRY_RUN=true` it runs step 2 and rolls it back, prints what it would change, and skips Keycloak entirely. Re-run the script after a real run — a clean repair reports `Nothing to do`.
+The script:
+
+1. Exports the current Keycloak roles, policies and folio user ids; classifies every matched policy and builds an old→new map.
+2. Reports anything it cannot synchronise — before either database is written.
+3. Rewrites stale role ids and folio user ids out of Keycloak's `resource_server_policy` names and descriptions (**policies and permissions**) and the role wiring in `policy_config`.
+4. In a single FOLIO transaction, fixes `role.id` and `policy.id` and every row that points at them — `user_role`, `role_capability`, `role_capability_set`, `role_loadable`, `role_loadable_permission`, `policy_roles`, `policy_users` — then rewrites stale ids out of `policy.name` / `policy.description`.
+
+**Keycloak is written before FOLIO, and that order matters.** The two databases share no transaction, so a run can die between the writes. Both id maps are derived from FOLIO's ids still differing from Keycloak's, and the Keycloak step only rewrites name strings — it never changes a Keycloak id. So a run interrupted between the two steps leaves everything the maps are built from intact, and simply running the script again finishes the job. Commit FOLIO first instead and that difference is gone, which is why the reverse order needs a saved map and a resume mode.
+
+Anything it cannot synchronise is reported, never silently skipped: unmatched policies, multi-entity or unresolvable policies (logged under "could not synchronise"), a broken FOLIO↔Keycloak user link (hard abort — the "users were recreated" migration is out of scope, this script has no folio-user-id map source), and any Keycloak name still embedding an id that resolves to no live entity (final `WARN`, exit 3).
+
+With `DRY_RUN=true` it skips Keycloak entirely, runs the FOLIO transaction and rolls it back, and prints what it would change — nothing is written to either database. Re-run the script after a real run: a clean repair reports `Nothing to repair`.
 
 ### Running it
 
@@ -578,57 +591,20 @@ DRY_RUN=true ./keycloak-scripts/repair-role-policy-uuids.sh   # report only, not
 | `KC_DB_URL`    | *(required)*                            | Keycloak DB connection URL                                   |
 | `FOLIO_DB_URL` | *(required)*                            | FOLIO DB connection URL                                      |
 | `TENANT`       | *(required)*                            | Tenant / realm name                                          |
-| `DRY_RUN`      | `false`                                 | Run the FOLIO transaction, roll it back, print a report      |
+| `DRY_RUN`      | `false`                                 | Skip the Keycloak rewrite, run the FOLIO transaction and roll it back, print a report |
 | `FORCE`        | `false`                                 | Skip roles that exist in FOLIO but not Keycloak (else abort) |
-| `WORK_DIR`     | `/tmp/repair-role-policy-uuids-$TENANT` | KC exports and the recovery map CSV                          |
+| `WORK_DIR`     | `/tmp/repair-role-policy-uuids-$TENANT` | Scratch space for the CSVs the run passes between the two database connections (`role_id_map.csv`, `user_id_map.csv`, plus the Keycloak exports) |
 
 ### Good to know
 
-- The FOLIO transaction takes `EXCLUSIVE` locks on the nine affected tables — readers are fine, concurrent writers wait — and a dry run takes them too. Between the FOLIO commit and the Keycloak rewrite, role management is briefly inconsistent.
+- The FOLIO transaction takes `EXCLUSIVE` locks on the nine affected tables — readers are fine, concurrent writers wait — and a dry run takes them too. Between the Keycloak rewrite and the FOLIO commit, role management is briefly inconsistent.
 - The script aborts before writing anything if a table's columns don't match what it expects, so a schema change in a newer `mod-roles-keycloak` can't corrupt data silently.
 - A dry run still creates and drops its staging tables in the DB (each `psql` call is a separate session); it never touches the tenant's own tables.
-- `WORK_DIR` keeps the old→new map CSV on purpose — it's what you recover from if the run dies after the FOLIO commit but before Keycloak (see below). Delete it once roles are editable again.
+- The CSVs left in `WORK_DIR` are the run's intermediate state, kept for diagnosis. They are not a recovery mechanism and nothing reads them on a later invocation — delete them whenever you like.
 - Keycloak caches authorization data in memory, so after a real run either roll-restart the Keycloak nodes or call `POST /admin/realms/{tenant}/clear-realm-cache` (clears the authz cache cluster-wide). `mod-roles-keycloak` doesn't cache role ids, but its config caches have a 3600s TTL — restart it or wait out the TTL before managing the repaired roles.
 
-### Recovering from a half-finished run
+### If a run fails part-way
 
-If the FOLIO transaction commits but the Keycloak rewrite fails, a re-run sees ids already matching, computes an empty map, and stops — pointing you here. Finish the Keycloak side by hand from the map CSV the failed run left in `WORK_DIR`:
+Run it again. There is no recovery mode and no state to carry over: the write order means an interrupted run leaves the id maps re-derivable, so a plain re-run picks up wherever the last one stopped and reports `Nothing to repair` once everything is aligned.
 
-```bash
-psql "$KC_DB_URL" -v ON_ERROR_STOP=1 \
-  -c "DROP TABLE IF EXISTS role_uuid_map_staging;
-      CREATE TABLE role_uuid_map_staging (old_id uuid, new_id uuid, name text);" \
-  -c "\copy role_uuid_map_staging FROM '/tmp/repair-role-policy-uuids-${TENANT}/role_id_map.csv' WITH (FORMAT csv, HEADER true)"
-
-psql "$KC_DB_URL" -v ON_ERROR_STOP=1 <<SQL
-BEGIN;
-UPDATE resource_server_policy rsp
-SET name = replace(rsp.name, m.old_id::text, m.new_id::text)
-FROM role_uuid_map_staging m
-WHERE rsp.resource_server_id IN (
-        SELECT c.id FROM client c WHERE c.realm_id = (SELECT id FROM realm WHERE name = '${TENANT}'))
-  AND strpos(rsp.name, m.old_id::text) > 0;
-DO \$\$
-DECLARE n bigint;
-BEGIN
-  LOOP
-    UPDATE policy_config pc
-    SET value = replace(pc.value, m.old_id::text, m.new_id::text)
-    FROM role_uuid_map_staging m
-    WHERE pc.name = 'roles' AND strpos(pc.value, m.old_id::text) > 0
-      AND pc.policy_id IN (
-        SELECT rsp.id FROM resource_server_policy rsp
-        JOIN client c ON rsp.resource_server_id = c.id
-        WHERE c.realm_id = (SELECT id FROM realm WHERE name = '${TENANT}'));
-    GET DIAGNOSTICS n = ROW_COUNT;
-    EXIT WHEN n = 0;
-  END LOOP;
-END
-\$\$;
-COMMIT;
-SQL
-
-psql "$KC_DB_URL" -c "DROP TABLE role_uuid_map_staging;"
-```
-
-Then re-run the script — it must report `Nothing to do`, and invalidate the Keycloak cache as above.
+If the FOLIO transaction itself looks wrong rather than merely interrupted, restore the schema from the `pg_dump` you took first — and then re-run, because a restore rolls back FOLIO only and Keycloak may already carry the rewritten names.

--- a/keycloak-scripts/repair-role-policy-uuids.sh
+++ b/keycloak-scripts/repair-role-policy-uuids.sh
@@ -33,22 +33,65 @@
 #
 # WHAT IT SYNCHRONISES. role.id and policy.id (FOLIO adopts Keycloak's), the FOLIO child tables
 # referencing them, and every name/description string embedding a role id or folio user id on BOTH
-# sides (policies AND permissions). Anything it cannot synchronise is reported, never silently
-# skipped: unmatched policies, multi-entity or unresolvable policies, and — for the out-of-scope
-# "users were recreated" case — a hard abort (this script has no folio-user-id map source).
+# sides (policies AND permissions).
+#
+# FAILURE POLICY — BEST EFFORT. The two databases are snapshots of the same tenant taken at
+# different moments, and no run can assume they agree everywhere. So: repair every entity that maps
+# 1:1, skip every entity that does not, and report the skipped ones. An anomaly in the DATA does not
+# abort the run — aborting would block the entities that ARE repairable, which on a live migration is
+# the worse outcome.
+# Consequently this script NEVER deletes a role, policy or permission. (It does DELETE and reinsert
+# child rows inside its own transaction, because the FKs are neither ON UPDATE CASCADE nor
+# deferrable — that is a rewrite, not a removal.) Removing a leftover is a separate, deliberate
+# operation for an operator who has confirmed what depends on it.
+#
+# The skip classes, all reported: 'multi' / 'unresolved' (key is not usable), 'folio_only' /
+# 'kc_only' (no counterpart), 'ambiguous' (several policies share one key — see below), duplicate
+# Keycloak role names, roles present in FOLIO but absent from Keycloak, FOLIO policy types outside
+# ROLE/USER/TIME (a type a later mod-roles-keycloak may add, which this script cannot key), a stale
+# FOLIO-to-Keycloak user link, and map rows dropped because rewriting them would collide on a
+# Keycloak policy name.
+#
+# EXIT CODES. 0 = ran to completion (skips may have been reported — read them). 3 = ran, wrote, but a
+# Keycloak name still embeds an id that no live entity and no reported skip accounts for, or the
+# leftover count could not be read; the databases are written, the run is simply not certified clean.
+# 1 = aborted. The abort cases are: cannot work at all (missing env var, realm, schema, or a query
+# the run depends on failing), or a write failed. Two data-driven aborts also survive inside the
+# transactions, both deliberate because continuing would corrupt: the policy_config remap failing to
+# converge (a chained or swapped map) and the closing assertion that every uniquely-named role now
+# carries Keycloak's id. Both roll their transaction back.
+#
+# ABORT DOES NOT ALWAYS MEAN "NOTHING HAPPENED". Each write is a single transaction, but there are
+# TWO of them in two databases. An abort during or before the Keycloak rewrite leaves both untouched;
+# an abort in the FOLIO transaction rolls FOLIO back while the Keycloak rewrite has already committed,
+# leaving the sides half-aligned. That state is designed for — re-running finishes the job — but do
+# not read exit 1 as "no change".
+#
+# AMBIGUOUS KEYS are the normal residue of an environment running mod-users-keycloak 3.0.x, where a
+# module system user receives its capabilities by DIRECT user-capability assignment: every change of
+# that user's folio id orphans its 'Policy for user: <old id>' and the next assignment creates a new
+# one, so Keycloak ends up holding several policies that all resolve to the same live user. Nothing
+# here can choose between them, so both sides step aside and are reported. This is not a dead end:
+# remove the surplus policy on whichever side actually holds more than one — the report prints the
+# per-key counts for both sides — and re-run; the key becomes 1:1 and the pair repairs itself. Note
+# that a key duplicated on the FOLIO side is demoted on the Keycloak side too, so "delete it in
+# Keycloak" is NOT universal advice. (The class disappears for good on mod-users-keycloak 4.x, where
+# system users go through a default role instead of direct user-capability assignment.)
 #
 # WRITE ORDER — DO NOT SWAP. Keycloak is rewritten first, the FOLIO transaction commits second.
 # The two databases share no transaction, so a run can die between them; this order is what makes a
 # plain re-run sufficient. Both id maps are derived from FOLIO's ids still differing from Keycloak's,
-# and the Keycloak step rewrites only name/description STRINGS — never Keycloak ids. So after a crash
+# the Keycloak step never changes a Keycloak PRIMARY KEY — it rewrites name/description strings and
+# the role id references inside policy_config, both of which are derived from the maps. So after a crash
 # in between, the next run re-derives exactly the same maps and finishes. Commit FOLIO first instead
 # and the difference the maps are built from is gone, which is why that ordering needs a persisted
 # map and a resume mode. It had one; it was removed on purpose.
 #
 # Required: KC_DB_URL, FOLIO_DB_URL (postgresql://...), TENANT (realm name, e.g. "diku")
-# Optional: DRY_RUN — "true": skip the Keycloak rewrite, run the FOLIO transaction and ROLLBACK,
-#                     print the report. Nothing is written to either database. Default: false.
-#           FORCE   — "true": skip (instead of abort on) roles that exist in FOLIO but not Keycloak.
+# Optional: DRY_RUN — exactly the string "true" (anything else, including "1"/"yes", is a REAL run):
+#                     skip the Keycloak rewrite, run the FOLIO transaction and ROLLBACK, print the
+#                     report. No tenant data is written to either database; the run still creates and
+#                     drops its own staging tables in the FOLIO schema, and reads Keycloak.
 #                     Default: false.
 #           WORK_DIR — Scratch space for the CSVs the run passes between the two databases; kept
 #                     afterwards for diagnosis only. Default: /tmp/repair-role-policy-uuids-$TENANT
@@ -75,43 +118,109 @@ require_env() {
 require_env KC_DB_URL FOLIO_DB_URL TENANT
 
 DRY_RUN="${DRY_RUN:-false}"
-FORCE="${FORCE:-false}"
 WORK_DIR="${WORK_DIR:-/tmp/repair-role-policy-uuids-$TENANT}"
 SCHEMA="${TENANT}_mod_roles_keycloak"
 # The maps are computed in FOLIO but applied in Keycloak; these CSVs are the transport between the
 # two connections, nothing more. They are not a recovery mechanism — a failed run is re-run.
 ROLE_MAP_CSV="$WORK_DIR/role_id_map.csv"     # old_id,new_id,name  (role UUIDs, FOLIO→KC)
 USER_MAP_CSV="$WORK_DIR/user_id_map.csv"     # old_id,new_id       (folio user ids in KC names)
-KC_LEFTOVER=0                                # set by kc_rewrite; read by the final status
+KC_LEFTOVER=0                                # set by refresh_kc_leftover; read by the final status
+ur_total=0; ur_matched=0                     # set by the pre-flight; read by report_skipped
+SKIPPED_ROLE_NAMES=""                        # set by the pre-flight; read by report_skipped
+FOLIO_ONLY_ROLES=""                          # set by the pre-flight; read by report_skipped
 mkdir -p "$WORK_DIR"
 
 # psql wrappers. NOTE: psql does NOT interpolate :variables in `-c` strings, and \copy interpolates
 # nothing — statements using :'tenant'/:"schema" must go via stdin, and \copy lines must have the
 # schema/path expanded by bash.
+# Keycloak has no per-tenant schema to hide in and these tables must outlive a single psql session
+# (written by \copy, read by the rewrite), so they cannot be TEMP. Qualify them by tenant instead:
+# two repairs running against the same Keycloak cluster for different tenants would otherwise share
+# one table name, and either one's DROP would destroy the other's map mid-run.
+KC_TBL_SUFFIX=$(printf '%s' "$TENANT" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '_')
+KC_ROLE_MAP_TBL="role_uuid_map_staging_$KC_TBL_SUFFIX"
+KC_USER_MAP_TBL="user_uuid_map_staging_$KC_TBL_SUFFIX"
+
 run_folio() { psql "$FOLIO_DB_URL" -v ON_ERROR_STOP=1 -v schema="$SCHEMA" -v tenant="$TENANT" "$@"; }
-run_kc()    { psql "$KC_DB_URL"    -v ON_ERROR_STOP=1 -v tenant="$TENANT" "$@"; }
+run_kc()    { psql "$KC_DB_URL"    -v ON_ERROR_STOP=1 -v tenant="$TENANT" \
+                       -v rolemap="$KC_ROLE_MAP_TBL" -v usermap="$KC_USER_MAP_TBL" "$@"; }
 q_folio()   { run_folio -qtA "$@"; }
 q_kc()      { run_kc -qtA "$@"; }
 
+# The leftover count runs AFTER the Keycloak rewrite has committed, so a failure here must not abort:
+# the write already happened and the FOLIO transaction still has to run. Degrade to an unknown count
+# and say so, rather than dying between the two writes with no output.
+refresh_kc_leftover() {
+    local n
+    if n=$(kc_unresolved_count); then
+        KC_LEFTOVER="${n:-0}"
+    else
+        KC_LEFTOVER="?"
+        warn "Could not count leftover Keycloak names — the query failed. Writes already made stand; re-run for a clean verdict."
+    fi
+}
+
+# Ids embedded in the NAME of a Keycloak policy this run deliberately skipped. Such an id is stale by
+# design and will stay stale — the script does not rewrite a policy it could not match, and never
+# deletes one. Counting it as leftover would make a tenant whose steady state includes a skip class
+# permanently "INCOMPLETE": the run could never reach exit 0 and 'Nothing to repair' would be
+# unreachable advice. So these ids are EXPLAINED and excluded from the leftover count; what remains
+# is a stale id attributable to no reported skip, which is the thing actually worth investigating.
+# The list is computed in FOLIO and inlined into the Keycloak query as SQL literals, NOT staged in a
+# table: the leftover count runs on the read-only DRY_RUN path too, and creating a table there would
+# both break "nothing is written" and make a read-only Keycloak endpoint unusable for a preview.
+# Inlining is safe because every value comes from a [0-9a-fA-F-]{36} capture and cannot carry a quote;
+# it travels on stdin, so there is no argument-length limit either.
+EXPLAINED_IDS=""    # set by collect_explained_ids; read by kc_unresolved_count
+collect_explained_ids() {
+    EXPLAINED_IDS=$(q_folio <<'SQL'
+SELECT string_agg(DISTINCT quote_literal(uid), ',')
+FROM (
+  SELECT substring(name FROM 'for (?:role|user):? ''?([0-9a-fA-F-]{36})') AS uid
+  FROM :"schema".kc_policies_staging
+  WHERE status IN ('ambiguous','kc_only','multi','unresolved')
+) d
+WHERE uid IS NOT NULL;
+SQL
+) || die "Failed to collect the ids explained by a reported skip."
+}
+
 # Count Keycloak names of the form 'Policy/…​ for role|user: <id>' whose embedded id resolves to
-# neither a live realm role nor a live folio user (user_id attribute). Used twice: as work detection
-# before the run (names left pointing at entities the migration replaced) and as the leftover check
-# after the rewrite (a stale id no map covered — e.g. a user with permissions but no policy).
+# neither a live realm role nor a live folio user (user_id attribute) AND is not explained by a
+# reported skip. Read-only. Used for work detection before the run (names left pointing at entities
+# the migration replaced) and as the leftover check after the rewrite (a stale id no map covered —
+# e.g. a user with permissions but no policy). Requires collect_explained_ids to have run.
 kc_unresolved_count() {
-    q_kc <<'SQL'
-WITH ids AS (
-  SELECT DISTINCT substring(rsp.name FROM 'for (?:role|user):? ''?([0-9a-fA-F-]{36})') AS uid
-  FROM resource_server_policy rsp
+    local explained="TRUE"
+    [[ -z "$EXPLAINED_IDS" ]] || explained="uid NOT IN ($EXPLAINED_IDS)"
+    q_kc <<SQL
+WITH scanned AS (
+  -- Descriptions carry the id too ("System generated policy for role: <id>") and are rewritten by
+  -- the same UPDATE, so a check that only read names would certify a run clean with a stale
+  -- description still in place — and the INCOMPLETE message claims to cover both.
+  SELECT rsp.name AS txt FROM resource_server_policy rsp
+  JOIN client c ON rsp.resource_server_id = c.id
+  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND rsp.name ~ 'for (role|user):? '
+  UNION ALL
+  SELECT rsp.description FROM resource_server_policy rsp
   JOIN client c ON rsp.resource_server_id = c.id
   WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
-    AND rsp.name ~ 'for (role|user):? '
+    AND coalesce(rsp.description, '') ~ 'for (role|user):? '
+),
+ids AS (
+  SELECT DISTINCT substring(txt FROM 'for (?:role|user):? ''?([0-9a-fA-F-]{36})') AS uid FROM scanned
 )
 SELECT count(*) FROM ids
 WHERE uid IS NOT NULL
+  AND $explained
   AND uid NOT IN (SELECT id::text FROM keycloak_role
                   WHERE realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND client_role = false)
+  -- ua.value is nullable (upstream declares no NOT NULL, and 24.0.0 added an explicit NULL path):
+  -- a single NULL in a NOT IN subquery makes the whole predicate NULL for every row, so the count
+  -- would silently come back 0 and certify a dirty realm as clean.
   AND uid NOT IN (SELECT ua.value FROM user_attribute ua JOIN user_entity ue ON ue.id = ua.user_id
-                  WHERE ua.name = 'user_id' AND ue.realm_id = (SELECT id FROM realm WHERE name = :'tenant'));
+                  WHERE ua.name = 'user_id' AND ua.value IS NOT NULL
+                    AND ue.realm_id = (SELECT id FROM realm WHERE name = :'tenant'));
 SQL
 }
 
@@ -123,25 +232,56 @@ DROP TABLE IF EXISTS :"schema".policy_key_staging;
 DROP TABLE IF EXISTS :"schema".role_id_map_staging;
 DROP TABLE IF EXISTS :"schema".kc_user_ids_staging;
 SQL
-    run_kc -c "DROP TABLE IF EXISTS role_uuid_map_staging; DROP TABLE IF EXISTS user_uuid_map_staging;" >/dev/null 2>&1 || true
+    run_kc -c "DROP TABLE IF EXISTS $KC_ROLE_MAP_TBL; DROP TABLE IF EXISTS $KC_USER_MAP_TBL;" >/dev/null 2>&1 || true
 }
 
-# Everything this run could NOT synchronise. Called before every exit that follows classification —
-# including the "nothing to repair" ones, where silence would otherwise read as "all clear".
-# Reads the staging tables, so it must run before cleanup_staging; uses ur_total/ur_matched from
-# the pre-flight, so it must run after step 3.
+# Everything this run could NOT synchronise, split by what the operator has to DO about it — a flat
+# list reads as one undifferentiated pile, and these classes call for opposite actions. Called before
+# every exit that follows classification, including the "nothing to repair" ones, where silence would
+# otherwise read as "all clear". Reads the staging tables, so it must run before cleanup_staging;
+# reads ur_total/ur_matched, SKIPPED_ROLE_NAMES and FOLIO_ONLY_ROLES from the pre-flight, so it must
+# run after step 3.
+report_class() {   # $1 = staging table, $2 = status list (SQL literals), $3 = side label
+    q_folio -v tbl="$1" -v side="$3" <<SQL || die "Failed to collect the report for status $2."
+SELECT string_agg(rpad(:'side', 6) || class || ' "' || name || '"' ||
+                  CASE WHEN status = 'ambiguous' THEN '  key=' || key ELSE '' END, chr(10) ORDER BY key, name)
+FROM :"schema".:"tbl" WHERE status IN ($2);
+SQL
+}
+
 report_skipped() {
-    local skipped
-    skipped=$(q_folio <<'SQL'
-SELECT string_agg(src || ' ' || class || ' "' || name || '" [' || status || ']', chr(10) ORDER BY status, name)
+    local ambiguous_kc ambiguous_folio ambiguous_keys folio_only kc_only unusable_folio unusable_kc stale_users="" unknown_types
+    ambiguous_kc=$(report_class    kc_policies_staging "'ambiguous'"          KC)
+    ambiguous_folio=$(report_class policy_key_staging  "'ambiguous'"          FOLIO)
+    # Per-key counts, because the remedy depends on WHICH side is duplicated: a key duplicated only in
+    # FOLIO is not fixed by deleting anything in Keycloak. Telling an operator otherwise mid-incident
+    # is worse than telling them nothing.
+    ambiguous_keys=$(q_folio <<'SQL'
+SELECT string_agg('   ' || key || '  ->  keycloak=' || kc_n || '  folio=' || f_n, chr(10) ORDER BY key)
 FROM (
-  SELECT 'FOLIO' AS src, class, name, status FROM :"schema".policy_key_staging  WHERE status IN ('folio_only','multi','unresolved')
-  UNION ALL
-  SELECT 'KC',    class, name, status FROM :"schema".kc_policies_staging WHERE status IN ('kc_only','multi','unresolved')
+  SELECT k.key,
+         (SELECT count(*) FROM :"schema".kc_policies_staging x WHERE x.key = k.key AND x.status = 'ambiguous') AS kc_n,
+         (SELECT count(*) FROM :"schema".policy_key_staging  y WHERE y.key = k.key AND y.status = 'ambiguous') AS f_n
+  FROM (SELECT DISTINCT key FROM :"schema".kc_policies_staging WHERE status = 'ambiguous') k
 ) d;
 SQL
-) || die "Failed to collect the skipped-policy report."
-    local stale_users=""
+) || die "Failed to summarise ambiguous keys."
+    folio_only=$(report_class      policy_key_staging  "'folio_only'"         FOLIO)
+    kc_only=$(report_class         kc_policies_staging "'kc_only'"            KC)
+    unusable_folio=$(report_class  policy_key_staging  "'multi','unresolved'" FOLIO)
+    unusable_kc=$(report_class     kc_policies_staging "'multi','unresolved'" KC)
+
+    # A policy type this script does not know is worse than an unmatched one: it never enters the
+    # staging tables at all, so without this it would be neither repaired nor reported — silently
+    # invisible, which is exactly what the failure policy above forbids. A later mod-roles-keycloak
+    # may add a type; this line is how the operator finds out instead of guessing.
+    unknown_types=$(q_folio <<'SQL'
+SELECT string_agg(t, ', ' ORDER BY t) FROM (
+  SELECT DISTINCT type::text || ' (' || count(*) OVER (PARTITION BY type) || ')' AS t
+  FROM :"schema".policy WHERE type::text NOT IN ('ROLE','USER','TIME')) d;
+SQL
+) || die "Failed to check for unknown FOLIO policy types."
+
     if [[ "$ur_matched" != "$ur_total" ]]; then
         stale_users=$(q_folio <<'SQL'
 SELECT string_agg(DISTINCT ur.user_id::text, chr(10))
@@ -151,14 +291,59 @@ WHERE k.folio_user_id IS NULL;
 SQL
 ) || die "Failed to collect the stale user-link report."
     fi
-    if [[ -n "$skipped" || -n "$stale_users" ]]; then
-        warn "Could not synchronise (reported, not repaired):"
-        [[ -n "$skipped" ]] && printf '%s\n' "$skipped" >&2
-        [[ -n "$stale_users" ]] && warn "FOLIO user_role.user_id not known to Keycloak (stale user link):" && printf '%s\n' "$stale_users" >&2
-        warn "(Anything created after the Keycloak export also lands here; re-run to confirm it is genuine.)"
-    else
-        log "Could not synchronise: nothing — every policy on both sides found its counterpart."
+
+    if [[ -z "$ambiguous_kc$ambiguous_folio$ambiguous_keys$folio_only$kc_only$unusable_folio$unusable_kc$stale_users$SKIPPED_ROLE_NAMES$FOLIO_ONLY_ROLES$unknown_types" ]]; then
+        log "Could not synchronise: nothing — every role and policy on both sides found its counterpart."
+        return 0
     fi
+
+    warn "======== NOT REPAIRED (skipped by design, nothing was deleted) ========"
+
+    if [[ -n "$ambiguous_kc$ambiguous_folio" ]]; then
+        warn "-- AMBIGUOUS: several policies resolve to one entity, so no id can be assigned"
+        warn "   deterministically. ACTION: on whichever side shows a count above 1 below, remove the"
+        warn "   surplus policy (in Keycloak: the policy and its permissions), then re-run — once the"
+        warn "   key is 1:1 the pair repairs itself. A count above 1 on the FOLIO side is NOT fixed by"
+        warn "   deleting anything in Keycloak."
+        [[ -n "$ambiguous_keys" ]] && printf '%s\n' "$ambiguous_keys" >&2
+        [[ -n "$ambiguous_kc"    ]] && printf '%s\n' "$ambiguous_kc" >&2
+        [[ -n "$ambiguous_folio" ]] && printf '%s\n' "$ambiguous_folio" >&2
+    fi
+    if [[ -n "$folio_only" ]]; then
+        warn "-- FOLIO POLICY WITH NO KEYCLOAK COUNTERPART: mod-roles-keycloak addresses Keycloak by the"
+        warn "   FOLIO policy id, so the next update of these will hit a missing object. This is a live"
+        warn "   breakage, not residue — it usually means the realm snapshot predates the FOLIO schema."
+        printf '%s\n' "$folio_only" >&2
+    fi
+    if [[ -n "$kc_only" ]]; then
+        warn "-- KEYCLOAK-ONLY: no FOLIO counterpart. Harmless where it is (Keycloak still enforces it),"
+        warn "   but unmanaged: mod-roles-keycloak will never find or revoke it. Clean up deliberately."
+        printf '%s\n' "$kc_only" >&2
+    fi
+    if [[ -n "$unusable_folio$unusable_kc" ]]; then
+        warn "-- UNUSABLE KEY: policy references several entities ('multi') or none this script can"
+        warn "   resolve ('unresolved', e.g. a policy over a CLIENT role). Not repairable by id matching."
+        [[ -n "$unusable_folio" ]] && printf '%s\n' "$unusable_folio" >&2
+        [[ -n "$unusable_kc"    ]] && printf '%s\n' "$unusable_kc" >&2
+    fi
+    if [[ -n "$SKIPPED_ROLE_NAMES" ]]; then
+        warn "-- DUPLICATE KEYCLOAK ROLE NAMES: role name is this script's only stable key, so these"
+        warn "   roles and everything hanging off them were left untouched: $SKIPPED_ROLE_NAMES"
+    fi
+    if [[ -n "$FOLIO_ONLY_ROLES" ]]; then
+        warn "-- ROLES IN FOLIO BUT NOT IN KEYCLOAK: no id to adopt, left as they are: $FOLIO_ONLY_ROLES"
+    fi
+    if [[ -n "$unknown_types" ]]; then
+        warn "-- UNKNOWN FOLIO POLICY TYPE(S): outside ROLE/USER/TIME, so this script never even looked"
+        warn "   at them. A newer mod-roles-keycloak may have added a type — the script needs teaching"
+        warn "   before it can repair these: $unknown_types"
+    fi
+    if [[ -n "$stale_users" ]]; then
+        warn "-- FOLIO user_role.user_id NOT KNOWN TO KEYCLOAK (stale user link):"
+        printf '%s\n' "$stale_users" >&2
+    fi
+    warn "(Anything created after the Keycloak export also lands here; re-run to confirm it is genuine.)"
+    warn "======================================================================"
 }
 
 # ==========================================================================================
@@ -170,61 +355,93 @@ kc_rewrite() {
     log "[6] Keycloak name/description rewrite..."
 
     run_kc <<'SQL' || die "Failed to create Keycloak staging tables."
-DROP TABLE IF EXISTS role_uuid_map_staging;
-DROP TABLE IF EXISTS user_uuid_map_staging;
-CREATE TABLE role_uuid_map_staging (old_id uuid, new_id uuid, name text);
-CREATE TABLE user_uuid_map_staging (old_id uuid, new_id uuid);
+DROP TABLE IF EXISTS :"rolemap";
+DROP TABLE IF EXISTS :"usermap";
+CREATE TABLE :"rolemap" (old_id uuid, new_id uuid, name text);
+CREATE TABLE :"usermap" (old_id uuid, new_id uuid);
 SQL
-    run_kc -c "\copy role_uuid_map_staging (old_id, new_id, name) FROM '$ROLE_MAP_CSV' WITH (FORMAT csv, HEADER true);" \
+    run_kc -c "\copy $KC_ROLE_MAP_TBL (old_id, new_id, name) FROM '$ROLE_MAP_CSV' WITH (FORMAT csv, HEADER true);" \
         || die "Failed to load the role id map into Keycloak."
-    run_kc -c "\copy user_uuid_map_staging (old_id, new_id) FROM '$USER_MAP_CSV' WITH (FORMAT csv, HEADER true);" \
+    run_kc -c "\copy $KC_USER_MAP_TBL (old_id, new_id) FROM '$USER_MAP_CSV' WITH (FORMAT csv, HEADER true);" \
         || die "Failed to load the user id map into Keycloak."
 
     # Empty maps mean nothing embeds a stale id in Keycloak (only FOLIO ids had drifted, or the names
     # were already current) — a legitimate no-op, not an error.
     local map_rows
-    map_rows=$(q_kc -c "SELECT (SELECT count(*) FROM role_uuid_map_staging) + (SELECT count(*) FROM user_uuid_map_staging);")
+    map_rows=$(q_kc -c "SELECT (SELECT count(*) FROM $KC_ROLE_MAP_TBL) + (SELECT count(*) FROM $KC_USER_MAP_TBL);") \
+        || die "Failed to count the staged Keycloak id maps."
     if [[ "${map_rows:-0}" == "0" ]]; then
         log "No Keycloak-side rewrite needed (maps are empty)."
-        KC_LEFTOVER="$(kc_unresolved_count)"; KC_LEFTOVER="${KC_LEFTOVER:-0}"
+        refresh_kc_leftover
         return 0
     fi
 
-    # Abort cleanly rather than letting the UNIQUE (name, resource_server_id) constraint fire
-    # mid-rewrite. Nothing has been written to either database at this point.
-    local collision
-    collision=$(q_kc <<'SQL'
+    # A map row whose rewrite would land two policies on the same (resource_server_id, name) cannot
+    # be applied — UNIQUE would fire mid-rewrite. Drop those rows from the map instead of aborting:
+    # every other rewrite in the same run is unaffected and correct. A pre-existing duplicate name is
+    # impossible (the constraint already forbids it), so every collision group contains at least one
+    # rewritten row, and removing the ids it maps from is always enough to resolve it.
+    # Note the asymmetry this leaves behind: the FOLIO side still adopts Keycloak's id for such an
+    # entity, so its Keycloak NAME keeps the old id embedded. That residue is counted by
+    # kc_unresolved_count and reported as INCOMPLETE at the end — visible, not silent.
+    local excluded
+    excluded=$(q_kc <<'SQL'
 WITH m AS (
-  SELECT old_id::text AS old_id, new_id::text AS new_id FROM role_uuid_map_staging
+  SELECT old_id::text AS old_id, new_id::text AS new_id FROM :"rolemap"
   UNION ALL
-  SELECT old_id::text, new_id::text FROM user_uuid_map_staging),
+  SELECT old_id::text, new_id::text FROM :"usermap"),
 rewritten AS (
-  SELECT rsp.resource_server_id AS rs,
-         COALESCE((SELECT replace(rsp.name, m.old_id, m.new_id) FROM m
-                   WHERE strpos(rsp.name, m.old_id) > 0 LIMIT 1), rsp.name) AS nm
+  -- One LATERAL, ordered: two independent LIMIT 1 subqueries could take `hit` from one map row and
+  -- `nm` from another for a name matching several, and then exclude an innocent id.
+  SELECT rsp.resource_server_id AS rs, h.old_id AS hit,
+         COALESCE(replace(rsp.name, h.old_id, h.new_id), rsp.name) AS nm
   FROM resource_server_policy rsp
   JOIN client c ON rsp.resource_server_id = c.id
-  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant'))
-SELECT count(*) FROM (SELECT rs, nm FROM rewritten GROUP BY rs, nm HAVING count(*) > 1) d;
+  LEFT JOIN LATERAL (SELECT m.old_id, m.new_id FROM m
+                     WHERE strpos(rsp.name, m.old_id) > 0 ORDER BY m.old_id LIMIT 1) h ON true
+  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')),
+collided AS (SELECT rs, nm FROM rewritten GROUP BY rs, nm HAVING count(*) > 1)
+SELECT string_agg(DISTINCT r.hit, chr(44))
+FROM rewritten r JOIN collided c ON c.rs = r.rs AND c.nm = r.nm
+WHERE r.hit IS NOT NULL;
 SQL
-)
-    [[ "$collision" == "0" ]] || die "Keycloak rewrite would create $collision duplicate policy name(s). Nothing was written; resolve the duplicate names in Keycloak (maps for reference in $WORK_DIR) and re-run."
+) || die "Failed to check the Keycloak rewrite for name collisions."
+
+    if [[ -n "$excluded" ]]; then
+        warn "Keycloak rewrite would collide on policy names; dropping these ids from the map and"
+        warn "rewriting everything else. Their Keycloak names keep the old id and are reported as"
+        warn "INCOMPLETE at the end: $excluded"
+        run_kc -v excluded="$excluded" <<'SQL' || die "Failed to drop colliding rows from the Keycloak id maps."
+DELETE FROM :"rolemap" WHERE old_id::text = ANY (string_to_array(:'excluded', ','));
+DELETE FROM :"usermap" WHERE old_id::text = ANY (string_to_array(:'excluded', ','));
+SQL
+        map_rows=$(q_kc -c "SELECT (SELECT count(*) FROM $KC_ROLE_MAP_TBL) + (SELECT count(*) FROM $KC_USER_MAP_TBL);") \
+            || die "Failed to re-count the staged Keycloak id maps."
+        if [[ "${map_rows:-0}" == "0" ]]; then
+            log "Nothing left in the maps after excluding collisions — no Keycloak rewrite to do."
+            refresh_kc_leftover
+            return 0
+        fi
+    fi
 
     run_kc <<'SQL' || die "Keycloak rewrite failed; it is a single transaction, so nothing was written. Fix the cause and re-run."
 \set ON_ERROR_STOP on
 BEGIN;
--- psql does not interpolate :'tenant' inside the dollar-quoted DO body below; pass it via a
--- transaction-local GUC instead.
+-- psql interpolates neither :'tenant' nor :"rolemap" inside the dollar-quoted DO body below. The
+-- tenant travels as a transaction-local GUC; the tenant-qualified map table is copied into a temp
+-- table with a FIXED name, which the DO body can then reference literally.
 SELECT set_config('repair.tenant', :'tenant', true);
+CREATE TEMP TABLE role_map_local ON COMMIT DROP AS SELECT old_id, new_id FROM :"rolemap";
 
 -- Names + descriptions embedding a role id (policies and 'access for role ...' permissions) and a
 -- folio user id (policies and 'access for user ...' permissions). Both maps, one pass each: every
 -- target is a resource_server_policy row, so substring substitution covers all of them.
 UPDATE resource_server_policy rsp
 SET name        = replace(rsp.name,        m.old_id::text, m.new_id::text),
-    description = replace(coalesce(rsp.description, ''), m.old_id::text, m.new_id::text)
-FROM (SELECT old_id, new_id FROM role_uuid_map_staging
-      UNION ALL SELECT old_id, new_id FROM user_uuid_map_staging) m
+    description = CASE WHEN rsp.description IS NULL THEN NULL
+                       ELSE replace(rsp.description, m.old_id::text, m.new_id::text) END
+FROM (SELECT old_id, new_id FROM :"rolemap"
+      UNION ALL SELECT old_id, new_id FROM :"usermap") m
 WHERE rsp.resource_server_id IN (
         SELECT c.id FROM client c WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant'))
   AND (strpos(rsp.name, m.old_id::text) > 0 OR strpos(coalesce(rsp.description,''), m.old_id::text) > 0);
@@ -239,7 +456,7 @@ BEGIN
   LOOP
     UPDATE policy_config pc
     SET value = replace(pc.value, m.old_id::text, m.new_id::text)
-    FROM role_uuid_map_staging m
+    FROM role_map_local m
     WHERE pc.name = 'roles'
       AND strpos(pc.value, m.old_id::text) > 0
       AND pc.policy_id IN (
@@ -259,20 +476,23 @@ SQL
     # Leftover check: after all rewrites, any name still embedding an id that resolves to no live
     # entity is a stale id no map covered (e.g. a user with permissions but no policy). Reported, not
     # fatal, but the run ends on a WARN, not "complete".
-    KC_LEFTOVER="$(kc_unresolved_count)"
-    KC_LEFTOVER="${KC_LEFTOVER:-0}"
+    refresh_kc_leftover
 }
 
-log "tenant=$TENANT schema=$SCHEMA dry_run=$DRY_RUN force=$FORCE work_dir=$WORK_DIR"
+log "tenant=$TENANT schema=$SCHEMA dry_run=$DRY_RUN work_dir=$WORK_DIR"
 
 # ---------- Step 1: Export current roles, policies and user ids from Keycloak ----------
 
 log "[1] Exporting Keycloak realm roles, policies and user ids..."
 
-echo "SELECT 1 FROM realm WHERE name = :'tenant';" | q_kc | grep -q 1 \
-    || die "Realm '$TENANT' not found in Keycloak."
-echo "SELECT 1 FROM information_schema.schemata WHERE schema_name = :'schema';" | q_folio | grep -q 1 \
-    || die "Schema '$SCHEMA' not found in FOLIO database."
+# Captured, not piped into grep: under `pipefail` a `grep -q` that exits on the first match can
+# SIGPIPE psql and turn a present realm into "not found" — an abort stating the opposite of the truth.
+realm_present=$(echo "SELECT 1 FROM realm WHERE name = :'tenant';" | q_kc) \
+    || die "Failed to query Keycloak for realm '$TENANT'."
+[[ "$realm_present" == "1" ]] || die "Realm '$TENANT' not found in Keycloak."
+schema_present=$(echo "SELECT 1 FROM information_schema.schemata WHERE schema_name = :'schema';" | q_folio) \
+    || die "Failed to query the FOLIO database for schema '$SCHEMA'."
+[[ "$schema_present" == "1" ]] || die "Schema '$SCHEMA' not found in FOLIO database."
 
 q_kc <<'SQL' > "$WORK_DIR/kc_roles.csv" || die "Failed to export Keycloak realm roles."
 COPY (
@@ -311,7 +531,13 @@ COPY (
     -- inflate refs to 2 and get the policy written off as multi-entity. (The role branch above
     -- joins on a primary key, so count(*) is already one row per referenced entity there — and
     -- DISTINCT is not even available on it, json having no equality operator.)
-    SELECT p.id, count(DISTINCT e) AS refs, min(ua.value) AS ent
+    -- ent is NULL when the referenced user carries MORE THAN ONE distinct 'user_id' value: the
+    -- attribute PK is ID, not (NAME, USER_ID) (upstream jpa-changelog-1.4.0.xml:161-162), so that is
+    -- legal, and min() would silently key the policy to an arbitrary one of them — producing a
+    -- confident 'no counterpart' verdict instead of an honest 'cannot resolve'. NULL ent leaves the
+    -- key bare ('user:') and the policy is classified 'unresolved' and reported.
+    SELECT p.id, count(DISTINCT e) AS refs,
+           CASE WHEN count(DISTINCT ua.value) > 1 THEN NULL ELSE min(ua.value) END AS ent
     FROM pol p
     JOIN policy_config pc ON pc.policy_id = p.id AND pc.name = 'users' AND pc.value LIKE '[%'
     CROSS JOIN LATERAL json_array_elements_text(pc.value::json) e
@@ -374,14 +600,17 @@ WITH pol AS (
   FROM :"schema".policy p
   WHERE p.type IN ('ROLE','USER','TIME')
 ),
+-- count DISTINCT, not rows: neither policy_roles nor policy_users has a primary key or unique
+-- constraint (create-policy-schema.xml adds FKs only), so the same (policy, entity) pair can appear
+-- twice. count(*) would read that as multi-entity and skip a policy that references exactly one.
 role_ref AS (
-  SELECT pr.policy_id AS id, count(*) AS refs, min(r.name) AS ent
+  SELECT pr.policy_id AS id, count(DISTINCT pr.role_id) AS refs, min(r.name) AS ent
   FROM :"schema".policy_roles pr
   LEFT JOIN :"schema".role r ON r.id = pr.role_id
   GROUP BY pr.policy_id
 ),
 user_ref AS (
-  SELECT pu.policy_id AS id, count(*) AS refs, min(pu.user_id::text) AS ent
+  SELECT pu.policy_id AS id, count(DISTINCT pu.user_id) AS refs, min(pu.user_id::text) AS ent
   FROM :"schema".policy_users pu
   GROUP BY pu.policy_id
 )
@@ -397,13 +626,17 @@ LEFT JOIN role_ref rr ON rr.id = p.id
 LEFT JOIN user_ref ur ON ur.id = p.id;
 SQL
 
-# Role id map: same-named roles whose ids differ. Role NAME is the stable key.
+# Role id map: same-named roles whose ids differ. Role NAME is the stable key — so a name carried by
+# two Keycloak roles has no usable key at all and is left out of the map entirely (it would otherwise
+# produce two map rows for one FOLIO role and fan the id UPDATE out). The pre-flight reports them.
 run_folio <<'SQL' || die "Failed to build the role id map."
 INSERT INTO :"schema".role_id_map_staging (old_id, new_id, name)
 SELECT r.id, k.id, r.name
 FROM :"schema".role r
 JOIN :"schema".kc_roles_staging k ON k.name = r.name
-WHERE r.id IS DISTINCT FROM k.id;
+WHERE r.id IS DISTINCT FROM k.id
+  AND NOT EXISTS (SELECT 1 FROM :"schema".kc_roles_staging d
+                  WHERE d.name IS NOT DISTINCT FROM k.name GROUP BY d.name HAVING count(*) > 1);
 SQL
 
 # Status, computed once on both staging tables (read everywhere downstream):
@@ -433,93 +666,86 @@ WHERE k.status = 'candidate'
   AND k.key IN (SELECT key FROM :"schema".policy_key_staging WHERE status = 'matched');
 UPDATE :"schema".policy_key_staging SET status = 'folio_only' WHERE status = 'candidate';
 UPDATE :"schema".kc_policies_staging SET status = 'kc_only'   WHERE status = 'candidate';
+
+-- 'ambiguous': the key is not 1:1 — several policies on one side carry it, so the id UPDATE would
+-- fan out non-deterministically. Both sides step aside; skipped and reported, never guessed at.
+-- Keycloak first: that statement demotes the rows for keys duplicated on EITHER side, which lets the
+-- FOLIO statement read the resulting keys back instead of recomputing a set the first UPDATE has
+-- just changed. Every matched FOLIO key has at least one matched Keycloak row by construction, so
+-- reading them back is complete.
+UPDATE :"schema".kc_policies_staging SET status = 'ambiguous'
+WHERE status = 'matched' AND key IN (
+  SELECT key FROM :"schema".kc_policies_staging WHERE status = 'matched' GROUP BY key HAVING count(*) > 1
+  UNION
+  SELECT key FROM :"schema".policy_key_staging  WHERE status = 'matched' GROUP BY key HAVING count(*) > 1);
+UPDATE :"schema".policy_key_staging SET status = 'ambiguous'
+WHERE status = 'matched'
+  AND key IN (SELECT key FROM :"schema".kc_policies_staging WHERE status = 'ambiguous');
 SQL
 
 # ---------- Step 3: Pre-flight checks ----------
 
 log "[3] Pre-flight checks..."
 
-# Hard-coded reinsert column lists MUST match the live schema: an incomplete list would silently
-# NULL/reset columns on reinsert (DEFAULT columns do not error). Abort on drift.
-col_mismatch=$(q_folio <<'SQL'
-WITH expected(tbl, cols) AS (
-  VALUES
-    ('user_role',               ARRAY['user_id','role_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
-    ('role_capability',         ARRAY['role_id','capability_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
-    ('role_capability_set',     ARRAY['role_id','capability_set_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
-    ('role_loadable',           ARRAY['id','loaded_from_file']),
-    ('role_loadable_permission',ARRAY['role_loadable_id','folio_permission','capability_id','capability_set_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
-    ('policy_roles',            ARRAY['policy_id','role_id','required']),
-    ('policy_users',            ARRAY['policy_id','user_id'])
-),
-actual AS (
-  SELECT table_name::text AS tbl, array_agg(column_name::text ORDER BY column_name::text) AS cols
-  FROM information_schema.columns
-  WHERE table_schema = :'schema'
-  GROUP BY table_name
+# The FOLIO transaction copies child rows with SELECT *, so it needs no column inventory and cannot
+# be broken by a column being added or renamed elsewhere in the table. What it does need is the
+# handful of columns it joins and rewrites on. Only those are checked, and only their ABSENCE is
+# fatal — this is a guard against the script silently doing nothing, not a schema-version pin.
+missing_cols=$(q_folio <<'SQL'
+WITH required(tbl, col) AS (
+  VALUES ('role','id'), ('role','name'),
+         ('policy','id'), ('policy','name'), ('policy','description'), ('policy','type'),
+         ('user_role','role_id'), ('user_role','user_id'),
+         ('role_capability','role_id'), ('role_capability_set','role_id'),
+         ('role_loadable','id'), ('role_loadable_permission','role_loadable_id'),
+         ('policy_roles','policy_id'), ('policy_roles','role_id'),
+         ('policy_users','policy_id'), ('policy_users','user_id')
 )
-SELECT e.tbl || ' expected=' || (SELECT array_agg(c ORDER BY c) FROM unnest(e.cols) c)::text
-              || ' actual='   || COALESCE(a.cols::text, '<missing table>')
-FROM expected e
-LEFT JOIN actual a ON a.tbl = e.tbl
-WHERE a.cols IS NULL
-   OR (SELECT array_agg(c ORDER BY c) FROM unnest(e.cols) c) IS DISTINCT FROM a.cols;
+SELECT string_agg(r.tbl || '.' || r.col, ', ' ORDER BY r.tbl, r.col)
+FROM required r
+LEFT JOIN information_schema.columns c
+       ON c.table_schema = :'schema' AND c.table_name = r.tbl AND c.column_name = r.col
+WHERE c.column_name IS NULL;
 SQL
-)
-[[ -z "$col_mismatch" ]] || die "Schema drift detected; fix the script's column lists before running:
-$col_mismatch"
+) || die "Failed to inspect the FOLIO schema."
+[[ -z "$missing_cols" ]] || die "Schema does not provide the columns this script works on — it is not a
+mod_roles_keycloak schema, or the model changed. Missing: $missing_cols"
 
-# Duplicate role names would make the role map non-deterministic.
-dup_roles=$(echo 'SELECT string_agg(name, chr(44) ORDER BY name) FROM (SELECT name FROM :"schema".kc_roles_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio)
-[[ -z "$dup_roles" ]] || die "Duplicate realm role names in Keycloak (cannot map by name): $dup_roles"
+# Duplicate Keycloak role names: role name is the only stable key for the role map, so these roles
+# (and every child row hanging off them) are left untouched. Excluded from the map above, reported
+# here, never guessed at.
+SKIPPED_ROLE_NAMES=$(echo 'SELECT string_agg(name, chr(44) ORDER BY name) FROM (SELECT name FROM :"schema".kc_roles_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio) \
+    || die "Failed to check for duplicate Keycloak role names."
 
-# ABORT 1: duplicate effective key among match-eligible policies (either side). A duplicate key
-# fans out the id UPDATE non-deterministically. Report the keys and stop.
-dup_keys=$(q_folio <<'SQL'
-SELECT string_agg(src || ':' || key, chr(44) ORDER BY key) FROM (
-  SELECT 'FOLIO' AS src, key FROM :"schema".policy_key_staging  WHERE status = 'matched' GROUP BY key HAVING count(*) > 1
-  UNION ALL
-  SELECT 'KC',    key FROM :"schema".kc_policies_staging WHERE status = 'matched' GROUP BY key HAVING count(*) > 1
-) d;
-SQL
-)
-[[ -z "$dup_keys" ]] || die "Duplicate effective policy key(s) — cannot map deterministically: $dup_keys"
-
-# ABORT 2: user link broken (out-of-scope "users recreated" migration). If NONE of FOLIO's
-# user_role.user_id values is known to Keycloak as a user_id attribute, folio user ids were
-# regenerated and this script has no map source for them — abort. A partial overlap is repaired
-# where possible; the stale rows are enumerated in the report (see below), never silently passed.
-IFS='|' read -r ur_total ur_matched < <(q_folio <<'SQL'
+# User link: how much of FOLIO's user_role overlaps what Keycloak knows. Zero overlap means folio
+# user ids were regenerated and this script has no map source for them — but that is a statement
+# about the user-policy class only, and the role class is repaired regardless, so it warns rather
+# than aborts. The rows themselves are enumerated by report_skipped.
+# Captured before parsing, not piped through process substitution: `read < <(...)` throws the query's
+# exit status away, so a failed query and a real answer would be indistinguishable.
+ur_counts=$(q_folio <<'SQL'
 SELECT count(DISTINCT ur.user_id),
        count(DISTINCT ur.user_id) FILTER (WHERE k.folio_user_id IS NOT NULL)
 FROM :"schema".user_role ur
 LEFT JOIN :"schema".kc_user_ids_staging k ON k.folio_user_id = ur.user_id;
 SQL
-)
+) || die "Failed to measure the FOLIO-to-Keycloak user link."
+IFS='|' read -r ur_total ur_matched <<<"$ur_counts"
 ur_total="${ur_total:-0}"; ur_matched="${ur_matched:-0}"
-# Zero overlap is only evidence of regenerated user ids when there are enough rows for it to mean
-# something: on a nearly empty tenant the one or two users present may simply not be provisioned in
-# Keycloak yet (created in FOLIO, not yet synced), and aborting the whole repair over that would be
-# wrong. Below the sample size the mismatched rows still surface in the skipped report.
+# Zero overlap only means something when there are enough rows for it to: on a nearly empty tenant
+# the one or two users present may simply not be provisioned in Keycloak yet.
 USER_LINK_MIN_SAMPLE=3
 if [[ "$ur_total" -ge "$USER_LINK_MIN_SAMPLE" && "$ur_matched" == "0" ]]; then
-    die "User link broken: none of $ur_total FOLIO user_role.user_id values is known to Keycloak (user_id attribute). Folio user ids were regenerated — this migration ('users recreated') is out of scope; repair user provisioning first."
+    warn "User link broken: none of $ur_total FOLIO user_role.user_id values is known to Keycloak (user_id attribute) — folio user ids were regenerated. Nothing in the user-policy class can be mapped this run; roles are repaired anyway."
 fi
 
-# ABORT 3: roles present in FOLIO but not Keycloak (existing guard).
-folio_only_roles=$(q_folio <<'SQL'
+# Roles present in FOLIO but not in Keycloak: no id to adopt, so they keep the one they have.
+FOLIO_ONLY_ROLES=$(q_folio <<'SQL'
 SELECT string_agg(r.name || ' (' || r.id || ')', ', ' ORDER BY r.name)
 FROM :"schema".role r LEFT JOIN :"schema".kc_roles_staging k ON k.name = r.name
 WHERE k.id IS NULL;
 SQL
-)
-if [[ -n "$folio_only_roles" ]]; then
-    if [[ "$FORCE" == "true" ]]; then
-        warn "Roles present in FOLIO but not in Keycloak (FORCE => skipped, NOT repaired): $folio_only_roles"
-    else
-        die "Roles present in FOLIO but not in Keycloak (set FORCE=true to skip them): $folio_only_roles"
-    fi
-fi
+) || die "Failed to check for FOLIO-only roles."
 
 # ---------- Step 4: Work detection ----------
 
@@ -527,23 +753,39 @@ fi
 # names still embedding an id that resolves to nothing. Any one of them alone is a real repair — a
 # migration can regenerate folio user ids without moving a single policy id, which leaves nothing but
 # stale name strings.
-role_diff=$(echo 'SELECT count(*) FROM :"schema".role_id_map_staging;' | q_folio)
+role_diff=$(echo 'SELECT count(*) FROM :"schema".role_id_map_staging;' | q_folio) \
+    || die "Failed to count role id mismatches."
 policy_diff=$(q_folio <<'SQL'
 SELECT count(*) FROM :"schema".policy_key_staging f
 JOIN :"schema".kc_policies_staging k ON k.key = f.key AND k.status = 'matched'
 WHERE f.status = 'matched' AND f.id IS DISTINCT FROM k.id;
 SQL
-)
-kc_stale=$(kc_unresolved_count)
-log "    role id mismatches: $role_diff, policy id mismatches: $policy_diff, stale KC names: $kc_stale"
+) || die "Failed to count policy id mismatches."
+collect_explained_ids
+kc_stale=$(kc_unresolved_count) || die "Failed to count unexplained stale Keycloak names."
+# Fourth drift class, independent of the other three: a matched FOLIO policy whose NAME embeds a folio
+# user id that disagrees with its policy_users row. Ids can all be aligned and Keycloak's names
+# current while this is still stale — without counting it the run would report "Nothing to repair"
+# and skip the very UPDATE that fixes it.
+folio_name_diff=$(q_folio <<'SQL'
+SELECT count(*) FROM (
+  SELECT DISTINCT f.id
+  FROM :"schema".policy_key_staging f
+  JOIN :"schema".policy_users pu ON pu.policy_id = f.id
+  WHERE f.status = 'matched' AND f.key LIKE 'user:%'
+    AND substring(f.name FROM 'Policy for user: ([0-9a-fA-F-]{36})') IS DISTINCT FROM pu.user_id::text
+) d;
+SQL
+) || die "Failed to count stale FOLIO policy names."
+log "    role id mismatches: $role_diff, policy id mismatches: $policy_diff, stale FOLIO names: $folio_name_diff, unexplained stale KC names: $kc_stale"
 
 # Everything this run cannot synchronise, reported once, before either database is written — so it
 # is on the operator's screen whichever way the run ends. It reads only the staging tables, which
 # neither write touches, so the content is the same wherever it is called.
 report_skipped
 
-if [[ "$role_diff" == "0" && "$policy_diff" == "0" && "$kc_stale" == "0" ]]; then
-    log "Nothing to repair: FOLIO ids already match Keycloak and no name embeds a dead id."
+if [[ "$role_diff" == "0" && "$policy_diff" == "0" && "$folio_name_diff" == "0" && "$kc_stale" == "0" ]]; then
+    log "Nothing to repair: FOLIO ids already match Keycloak, and every name still embedding a dead id belongs to a policy reported above as skipped."
     cleanup_staging
     exit 0
 fi
@@ -582,7 +824,7 @@ tx_end="COMMIT"
 [[ "$DRY_RUN" == "true" ]] && tx_end="ROLLBACK"
 log "[7] FOLIO transaction (end=$tx_end)..."
 
-run_folio -v tx_end="$tx_end" <<'SQL' || die "FOLIO transaction failed (rolled back)."
+run_folio -v tx_end="$tx_end" <<'SQL' || die "FOLIO transaction failed and rolled back — but the Keycloak rewrite before it has already COMMITTED, so the two sides are now half-aligned. Fix the cause and re-run: the maps are re-derived from the ids that still differ, and the Keycloak rewrite is a no-op the second time."
 \set ON_ERROR_STOP on
 BEGIN;
 SET search_path TO :"schema";
@@ -611,34 +853,45 @@ CREATE TEMP TABLE user_map AS
   WHERE f.status = 'matched' AND f.key LIKE 'user:%'
     AND substring(f.name FROM 'Policy for user: ([0-9a-fA-F-]{36})') IS DISTINCT FROM pu.user_id::text;
 
--- Capture children with NEW ids substituted, then delete/update/reinsert: no FK is
--- ON UPDATE CASCADE or deferrable, and role_loadable is ON DELETE RESTRICT.
+-- Capture children, then delete/update/reinsert: no FK is ON UPDATE CASCADE or deferrable, and
+-- role_loadable is ON DELETE RESTRICT.
+-- The copies are taken with SELECT * and reinserted without a column list, so the script carries no
+-- inventory of these tables and a column added or renamed by a future mod-roles-keycloak migration
+-- flows through untouched. (Naming the columns instead means an out-of-date list silently resets
+-- whatever it omits — DEFAULTs do not error.) The id substitution is a separate UPDATE on the copy;
+-- one UPDATE touches each row at most once, so a map that chains A→B, B→C cannot double-apply.
 CREATE TEMP TABLE b_user_role AS
-  SELECT rm.new_id AS role_id, t.user_id, t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
-  FROM user_role t JOIN role_map rm ON rm.old_id = t.role_id;
+  SELECT t.* FROM user_role t JOIN role_map rm ON rm.old_id = t.role_id;
+UPDATE b_user_role b SET role_id = rm.new_id FROM role_map rm WHERE rm.old_id = b.role_id;
+
 CREATE TEMP TABLE b_role_capability AS
-  SELECT rm.new_id AS role_id, t.capability_id, t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
-  FROM role_capability t JOIN role_map rm ON rm.old_id = t.role_id;
+  SELECT t.* FROM role_capability t JOIN role_map rm ON rm.old_id = t.role_id;
+UPDATE b_role_capability b SET role_id = rm.new_id FROM role_map rm WHERE rm.old_id = b.role_id;
+
 CREATE TEMP TABLE b_role_capability_set AS
-  SELECT rm.new_id AS role_id, t.capability_set_id, t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
-  FROM role_capability_set t JOIN role_map rm ON rm.old_id = t.role_id;
+  SELECT t.* FROM role_capability_set t JOIN role_map rm ON rm.old_id = t.role_id;
+UPDATE b_role_capability_set b SET role_id = rm.new_id FROM role_map rm WHERE rm.old_id = b.role_id;
+
 CREATE TEMP TABLE b_role_loadable AS
-  SELECT rm.new_id AS id, t.loaded_from_file
-  FROM role_loadable t JOIN role_map rm ON rm.old_id = t.id;
+  SELECT t.* FROM role_loadable t JOIN role_map rm ON rm.old_id = t.id;
+UPDATE b_role_loadable b SET id = rm.new_id FROM role_map rm WHERE rm.old_id = b.id;
+
 CREATE TEMP TABLE b_role_loadable_permission AS
-  SELECT rm.new_id AS role_loadable_id, t.folio_permission, t.capability_id, t.capability_set_id,
-         t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
-  FROM role_loadable_permission t JOIN role_map rm ON rm.old_id = t.role_loadable_id;
+  SELECT t.* FROM role_loadable_permission t JOIN role_map rm ON rm.old_id = t.role_loadable_id;
+UPDATE b_role_loadable_permission b SET role_loadable_id = rm.new_id
+  FROM role_map rm WHERE rm.old_id = b.role_loadable_id;
+
 CREATE TEMP TABLE b_policy_roles AS
-  SELECT COALESCE(pm.new_id, t.policy_id) AS policy_id,
-         COALESCE(rm.new_id, t.role_id)   AS role_id, t.required
-  FROM policy_roles t
+  SELECT t.* FROM policy_roles t
   LEFT JOIN policy_map pm ON pm.old_id = t.policy_id
   LEFT JOIN role_map   rm ON rm.old_id = t.role_id
   WHERE pm.new_id IS NOT NULL OR rm.new_id IS NOT NULL;
+UPDATE b_policy_roles b SET policy_id = pm.new_id FROM policy_map pm WHERE pm.old_id = b.policy_id;
+UPDATE b_policy_roles b SET role_id   = rm.new_id FROM role_map   rm WHERE rm.old_id = b.role_id;
+
 CREATE TEMP TABLE b_policy_users AS
-  SELECT pm.new_id AS policy_id, t.user_id
-  FROM policy_users t JOIN policy_map pm ON pm.old_id = t.policy_id;
+  SELECT t.* FROM policy_users t JOIN policy_map pm ON pm.old_id = t.policy_id;
+UPDATE b_policy_users b SET policy_id = pm.new_id FROM policy_map pm WHERE pm.old_id = b.policy_id;
 
 DELETE FROM role_loadable_permission WHERE role_loadable_id IN (SELECT old_id FROM role_map);
 DELETE FROM role_loadable            WHERE id       IN (SELECT old_id FROM role_map);
@@ -658,7 +911,8 @@ UPDATE policy p SET id = m.new_id FROM policy_map m WHERE p.id = m.old_id;
 -- Names/descriptions embedding an OLD role id (role policies + descriptions).
 UPDATE policy p
 SET name        = replace(p.name,        m.old_id::text, m.new_id::text),
-    description = replace(coalesce(p.description, ''), m.old_id::text, m.new_id::text)
+    description = CASE WHEN p.description IS NULL THEN NULL
+                       ELSE replace(p.description, m.old_id::text, m.new_id::text) END
 FROM role_map m
 WHERE p.name LIKE '%' || m.old_id::text || '%'
    OR coalesce(p.description,'') LIKE '%' || m.old_id::text || '%';
@@ -666,35 +920,31 @@ WHERE p.name LIKE '%' || m.old_id::text || '%'
 -- FOLIO name already holds policy_users.user_id, which is the carry-over case).
 UPDATE policy p
 SET name        = replace(p.name,        m.old_id, m.new_id),
-    description = replace(coalesce(p.description, ''), m.old_id, m.new_id)
+    description = CASE WHEN p.description IS NULL THEN NULL
+                       ELSE replace(p.description, m.old_id, m.new_id) END
 FROM user_map m
 WHERE p.name LIKE '%' || m.old_id || '%'
    OR coalesce(p.description,'') LIKE '%' || m.old_id || '%';
 
-INSERT INTO role_loadable (id, loaded_from_file)
-  SELECT id, loaded_from_file FROM b_role_loadable;
-INSERT INTO role_loadable_permission
-  (role_loadable_id, folio_permission, capability_id, capability_set_id,
-   created_by_user_id, created_date, updated_by_user_id, updated_date)
-  SELECT * FROM b_role_loadable_permission;
-INSERT INTO user_role (role_id, user_id, created_by_user_id, created_date, updated_by_user_id, updated_date)
-  SELECT * FROM b_user_role;
-INSERT INTO role_capability (role_id, capability_id, created_by_user_id, created_date, updated_by_user_id, updated_date)
-  SELECT * FROM b_role_capability;
-INSERT INTO role_capability_set (role_id, capability_set_id, created_by_user_id, created_date, updated_by_user_id, updated_date)
-  SELECT * FROM b_role_capability_set;
-INSERT INTO policy_roles (policy_id, role_id, required)
-  SELECT * FROM b_policy_roles;
-INSERT INTO policy_users (policy_id, user_id)
-  SELECT * FROM b_policy_users;
+-- No column lists: the copies were taken with SELECT *, so they match the live tables by
+-- construction. See the note above the CREATE TEMP TABLEs.
+INSERT INTO role_loadable            SELECT * FROM b_role_loadable;
+INSERT INTO role_loadable_permission SELECT * FROM b_role_loadable_permission;
+INSERT INTO user_role                SELECT * FROM b_user_role;
+INSERT INTO role_capability          SELECT * FROM b_role_capability;
+INSERT INTO role_capability_set      SELECT * FROM b_role_capability_set;
+INSERT INTO policy_roles             SELECT * FROM b_policy_roles;
+INSERT INTO policy_users             SELECT * FROM b_policy_users;
 
--- Every role with a same-named Keycloak role must now carry the Keycloak id.
+-- Every role with exactly one same-named Keycloak role must now carry the Keycloak id. Names held by
+-- two Keycloak roles are deliberately outside the map, so they are outside the assertion too —
+-- otherwise a skip the script chose on purpose would blow up the transaction that honours it.
 DO $assert$
 DECLARE bad int;
 BEGIN
   SELECT count(*) INTO bad FROM role r
   WHERE r.id NOT IN (SELECT id FROM kc_roles_staging)
-    AND r.name IN (SELECT name FROM kc_roles_staging);
+    AND r.name IN (SELECT name FROM kc_roles_staging GROUP BY name HAVING count(*) = 1);
   IF bad > 0 THEN RAISE EXCEPTION 'ASSERT: % role(s) still have ids absent from Keycloak', bad; END IF;
 END
 $assert$;
@@ -717,12 +967,21 @@ if [[ "$DRY_RUN" == "true" ]]; then
     exit 0
 fi
 
-cleanup_staging
+if [[ "$KC_LEFTOVER" == "0" ]]; then
+    cleanup_staging
+else
+    warn "Staging tables kept in $SCHEMA for diagnosis (the classification behind the report below);"
+    warn "the next run drops and rebuilds them."
+fi
 log "Intermediate CSVs left in $WORK_DIR for diagnosis — safe to delete."
 warn "Keycloak caches authorization data in memory: rolling-restart all Keycloak nodes OR call"
 warn "POST /admin/realms/$TENANT/clear-realm-cache before actively managing the repaired roles."
+if [[ "$KC_LEFTOVER" == "?" ]]; then
+    warn "INCOMPLETE: the leftover count could not be read, so this run cannot certify the Keycloak side. Writes already made stand; re-run for a verdict."
+    exit 3
+fi
 if [[ "$KC_LEFTOVER" != "0" ]]; then
-    warn "INCOMPLETE: $KC_LEFTOVER Keycloak name(s)/description(s) still embed an id that resolves to no live role or user (a target absent from the maps — e.g. a user with permissions but no policy). A folio user id can be rebuilt from FOLIO on a re-run; a role id cannot, because its old→new mapping existed only while the two sides disagreed. Investigate before clearing caches."
+    warn "INCOMPLETE: $KC_LEFTOVER Keycloak name(s)/description(s) still embed an id that resolves to no live role or user AND belongs to no policy reported above — a target absent from the maps, e.g. a user with permissions but no policy. (Stale ids inside a reported skip are expected and are not counted here.) A folio user id can be rebuilt from FOLIO on a re-run; a role id cannot, because its old→new mapping existed only while the two sides disagreed. Investigate before clearing caches."
     exit 3
 fi
 log "Repair complete for tenant $TENANT. Re-run to verify: it must report 'Nothing to repair'."

--- a/keycloak-scripts/repair-role-policy-uuids.sh
+++ b/keycloak-scripts/repair-role-policy-uuids.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# repair-role-policy-uuids.sh — Repair role + policy UUID mapping after a realm migration
+# that regenerated Keycloak UUIDs: FOLIO's role.id / policy.id go stale and roles become
+# un-editable (404 from Keycloak). Role-and-policy counterpart of repair-policy-uuids.sh;
+# both are fixed in ONE FOLIO transaction because role ids are embedded in policy names
+# on both sides: ids are re-mapped by name BEFORE any name is rewritten.
+#
+# Required: KC_DB_URL, FOLIO_DB_URL (postgresql://...), TENANT (realm name, e.g. "diku")
+# Optional: DRY_RUN  — "true": run the FOLIO transaction and ROLLBACK, print the report,
+#                      skip the Keycloak step entirely. Default: false.
+#           FORCE    — "true": skip (instead of abort on) roles that exist in FOLIO but
+#                      not in Keycloak. Default: false.
+#           WORK_DIR — Where the role id map CSV is persisted.
+#                      Default: /tmp/repair-role-policy-uuids-$TENANT
+#
+# Production prerequisites: run in a maintenance window (the FOLIO transaction locks the
+# affected tables) and take a schema backup first:
+#   pg_dump "$FOLIO_DB_URL" -n "${TENANT}_mod_roles_keycloak" > roles_backup.sql
+
+set -euo pipefail
+
+log()  { printf '%s [%s] %s\n' "$(date -u +%FT%TZ)" "INFO"  "$1" >&2; }
+warn() { printf '%s [%s] %s\n' "$(date -u +%FT%TZ)" "WARN"  "$1" >&2; }
+die()  { printf '%s [%s] %s\n' "$(date -u +%FT%TZ)" "ERROR" "$1" >&2; exit "${2:-1}"; }
+
+require_env() {
+    local v
+    for v in "$@"; do
+        [[ -n "${!v:-}" ]] || die "Required environment variable not set: $v"
+    done
+}
+
+require_env KC_DB_URL FOLIO_DB_URL TENANT
+
+DRY_RUN="${DRY_RUN:-false}"
+FORCE="${FORCE:-false}"
+WORK_DIR="${WORK_DIR:-/tmp/repair-role-policy-uuids-$TENANT}"
+SCHEMA="${TENANT}_mod_roles_keycloak"
+MAP_CSV="$WORK_DIR/role_id_map.csv"
+mkdir -p "$WORK_DIR"
+
+# psql wrappers. NOTE: psql does NOT interpolate :variables in `-c` strings, and \copy
+# interpolates nothing at all — statements using :'tenant'/:"schema" must go via stdin,
+# and \copy lines must have the schema expanded by bash.
+run_folio() { psql "$FOLIO_DB_URL" -v ON_ERROR_STOP=1 -v schema="$SCHEMA" -v tenant="$TENANT" "$@"; }
+run_kc()    { psql "$KC_DB_URL"    -v ON_ERROR_STOP=1 -v tenant="$TENANT" "$@"; }
+q_folio()   { run_folio -qtA "$@"; }
+q_kc()      { run_kc -qtA "$@"; }
+
+cleanup_staging() {
+    run_folio <<SQL || warn "Failed to drop FOLIO staging tables."
+DROP TABLE IF EXISTS :"schema".kc_roles_staging;
+DROP TABLE IF EXISTS :"schema".kc_policies_staging;
+DROP TABLE IF EXISTS :"schema".role_id_map_staging;
+SQL
+    run_kc -c "DROP TABLE IF EXISTS role_uuid_map_staging;" >/dev/null 2>&1 || true
+}
+
+log "tenant=$TENANT schema=$SCHEMA dry_run=$DRY_RUN force=$FORCE work_dir=$WORK_DIR"
+
+# ---------- Step 1: Export current roles and policies from Keycloak ----------
+
+log "[1] Exporting Keycloak realm roles and policies..."
+
+echo "SELECT 1 FROM realm WHERE name = :'tenant';" | q_kc | grep -q 1 \
+    || die "Realm '$TENANT' not found in Keycloak."
+echo "SELECT 1 FROM information_schema.schemata WHERE schema_name = :'schema';" | q_folio | grep -q 1 \
+    || die "Schema '$SCHEMA' not found in FOLIO database."
+
+q_kc <<'SQL' > "$WORK_DIR/kc_roles.csv" || die "Failed to export Keycloak realm roles."
+COPY (
+    SELECT id, name FROM keycloak_role
+    WHERE realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND client_role = false
+) TO STDOUT WITH (FORMAT csv, HEADER true);
+SQL
+
+q_kc <<'SQL' > "$WORK_DIR/kc_policies.csv" || die "Failed to export Keycloak policies."
+COPY (
+    SELECT rsp.id, rsp.name
+    FROM resource_server_policy rsp
+    JOIN client c ON rsp.resource_server_id = c.id
+    WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
+) TO STDOUT WITH (FORMAT csv, HEADER true);
+SQL
+
+# ---------- Step 2: Stage the export in FOLIO and build the role map ---------
+
+log "[2] Staging Keycloak export in FOLIO..."
+
+run_folio <<'SQL' || die "Failed to create staging tables."
+DROP TABLE IF EXISTS :"schema".kc_roles_staging;
+DROP TABLE IF EXISTS :"schema".kc_policies_staging;
+DROP TABLE IF EXISTS :"schema".role_id_map_staging;
+CREATE TABLE :"schema".kc_roles_staging   (id uuid, name text);
+CREATE TABLE :"schema".kc_policies_staging (id uuid, name text);
+CREATE TABLE :"schema".role_id_map_staging (old_id uuid, new_id uuid, name text);
+SQL
+
+run_folio <<SQL || die "Failed to load staging tables."
+\\copy ${SCHEMA}.kc_roles_staging (id, name) FROM '$WORK_DIR/kc_roles.csv' WITH (FORMAT csv, HEADER true)
+\\copy ${SCHEMA}.kc_policies_staging (id, name) FROM '$WORK_DIR/kc_policies.csv' WITH (FORMAT csv, HEADER true)
+SQL
+
+run_folio <<'SQL' || die "Failed to build the role id map."
+INSERT INTO :"schema".role_id_map_staging (old_id, new_id, name)
+SELECT r.id, k.id, r.name
+FROM :"schema".role r
+JOIN :"schema".kc_roles_staging k ON k.name = r.name
+WHERE r.id IS DISTINCT FROM k.id;
+SQL
+
+# ---------- Step 3: Pre-flight checks -----------------------------------------
+
+log "[3] Pre-flight checks..."
+
+# Hard-coded reinsert column lists MUST match the live schema: an incomplete list would
+# silently NULL/reset columns on reinsert (DEFAULT columns do not error). Abort on drift.
+col_mismatch=$(q_folio <<'SQL'
+WITH expected(tbl, cols) AS (
+  VALUES
+    ('user_role',               ARRAY['user_id','role_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
+    ('role_capability',         ARRAY['role_id','capability_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
+    ('role_capability_set',     ARRAY['role_id','capability_set_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
+    ('role_loadable',           ARRAY['id','loaded_from_file']),
+    ('role_loadable_permission',ARRAY['role_loadable_id','folio_permission','capability_id','capability_set_id','created_by_user_id','created_date','updated_by_user_id','updated_date']),
+    ('policy_roles',            ARRAY['policy_id','role_id','required']),
+    ('policy_users',            ARRAY['policy_id','user_id'])
+),
+actual AS (
+  SELECT table_name::text AS tbl, array_agg(column_name::text ORDER BY column_name::text) AS cols
+  FROM information_schema.columns
+  WHERE table_schema = :'schema'
+  GROUP BY table_name
+)
+SELECT e.tbl || ' expected=' || (SELECT array_agg(c ORDER BY c) FROM unnest(e.cols) c)::text
+              || ' actual='   || COALESCE(a.cols::text, '<missing table>')
+FROM expected e
+LEFT JOIN actual a ON a.tbl = e.tbl
+WHERE a.cols IS NULL
+   OR (SELECT array_agg(c ORDER BY c) FROM unnest(e.cols) c) IS DISTINCT FROM a.cols;
+SQL
+)
+[[ -z "$col_mismatch" ]] || die "Schema drift detected; fix the script's column lists before running:
+$col_mismatch"
+
+# Names are the mapping keys — duplicates would make the repair non-deterministic.
+dup_roles=$(echo 'SELECT string_agg(name, chr(44)) FROM (SELECT name FROM :"schema".kc_roles_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio)
+[[ -z "$dup_roles" ]] || die "Duplicate realm role names in Keycloak (cannot map by name): $dup_roles"
+dup_policies=$(echo 'SELECT string_agg(name, chr(44)) FROM (SELECT name FROM :"schema".kc_policies_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio)
+[[ -z "$dup_policies" ]] || die "Duplicate policy names across Keycloak resource servers (cannot map by name): $dup_policies"
+
+folio_only=$(q_folio <<'SQL'
+SELECT string_agg(r.name || ' (' || r.id || ')', ', ')
+FROM :"schema".role r LEFT JOIN :"schema".kc_roles_staging k ON k.name = r.name
+WHERE k.id IS NULL;
+SQL
+)
+if [[ -n "$folio_only" ]]; then
+    if [[ "$FORCE" == "true" ]]; then
+        warn "Roles present in FOLIO but not in Keycloak (FORCE => skipped, NOT repaired): $folio_only"
+    else
+        die "Roles present in FOLIO but not in Keycloak (set FORCE=true to skip them): $folio_only"
+    fi
+fi
+
+# Work detection: role/policy id drift + stale role ids embedded in names (either side).
+role_diff=$(echo 'SELECT count(*) FROM :"schema".role_id_map_staging;' | q_folio)
+policy_diff=$(q_folio <<'SQL'
+SELECT count(*) FROM :"schema".policy p
+JOIN :"schema".kc_policies_staging k ON k.name = p.name
+WHERE p.id IS DISTINCT FROM k.id;
+SQL
+)
+folio_stale=$(q_folio <<'SQL'
+SET search_path TO :"schema";
+SELECT count(*) FROM policy
+WHERE name LIKE 'Policy for role: %'
+  AND substring(name FROM 'Policy for role: (.*)$') NOT IN (SELECT id::text FROM role);
+SQL
+)
+kc_stale=$(q_kc <<'SQL'
+WITH ids AS (
+  SELECT DISTINCT substring(rsp.name FROM 'for role:? ''?([0-9a-fA-F-]{36})') AS uid
+  FROM resource_server_policy rsp
+  JOIN client c ON rsp.resource_server_id = c.id
+  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
+    AND (rsp.name LIKE 'Policy for role: %' OR rsp.name LIKE '% access for role %')
+)
+SELECT count(*) FROM ids
+WHERE uid IS NOT NULL AND uid NOT IN (
+  SELECT id::text FROM keycloak_role
+  WHERE realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND client_role = false);
+SQL
+)
+log "    role id mismatches: $role_diff, policy id mismatches: $policy_diff, stale names: FOLIO=$folio_stale KC=$kc_stale"
+
+if [[ "$role_diff" == "0" && "$policy_diff" == "0" ]]; then
+    if [[ "$folio_stale" == "0" && "$kc_stale" == "0" ]]; then
+        log "Nothing to do: FOLIO ids already match Keycloak and no stale names. Exiting."
+        cleanup_staging
+        exit 0
+    fi
+    die "Ids match but stale names remain (FOLIO=$folio_stale, KC=$kc_stale) — a previous run likely failed between the FOLIO commit and the Keycloak step. See 'Manual recovery' in README.md (uses $MAP_CSV from that run)."
+fi
+
+# ---------- Step 4: Persist the role id map (recovery key) --------------------
+
+echo 'COPY (SELECT old_id, new_id, name FROM :"schema".role_id_map_staging) TO STDOUT WITH (FORMAT csv, HEADER true);' \
+    | q_folio > "$MAP_CSV" || die "Failed to write role id map."
+log "[4] Role id map written to $MAP_CSV"
+
+# ---------- Step 5: FOLIO transaction (id fix + name rewrite) -----------------
+
+tx_end="COMMIT"
+[[ "$DRY_RUN" == "true" ]] && tx_end="ROLLBACK"
+log "[5] FOLIO transaction (end=$tx_end)..."
+
+run_folio -v tx_end="$tx_end" <<'SQL' || die "FOLIO transaction failed (rolled back)."
+\set ON_ERROR_STOP on
+BEGIN;
+SET search_path TO :"schema";
+
+-- Block concurrent writers (mod-roles-keycloak) for the whole repair; readers pass.
+LOCK TABLE role, policy, user_role, role_capability, role_capability_set,
+           role_loadable, role_loadable_permission, policy_roles, policy_users
+IN EXCLUSIVE MODE;
+
+-- Maps must be built while names still embed the OLD role ids on both sides.
+CREATE TEMP TABLE role_map AS
+  SELECT old_id, new_id, name FROM role_id_map_staging;
+CREATE TEMP TABLE policy_map AS
+  SELECT p.id AS old_id, k.id AS new_id, p.name
+  FROM policy p JOIN kc_policies_staging k ON k.name = p.name
+  WHERE p.id IS DISTINCT FROM k.id;
+
+-- Capture children with NEW ids substituted, then delete/update/reinsert: no FK is
+-- ON UPDATE CASCADE or deferrable, and role_loadable is ON DELETE RESTRICT.
+CREATE TEMP TABLE b_user_role AS
+  SELECT rm.new_id AS role_id, t.user_id, t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
+  FROM user_role t JOIN role_map rm ON rm.old_id = t.role_id;
+CREATE TEMP TABLE b_role_capability AS
+  SELECT rm.new_id AS role_id, t.capability_id, t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
+  FROM role_capability t JOIN role_map rm ON rm.old_id = t.role_id;
+CREATE TEMP TABLE b_role_capability_set AS
+  SELECT rm.new_id AS role_id, t.capability_set_id, t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
+  FROM role_capability_set t JOIN role_map rm ON rm.old_id = t.role_id;
+CREATE TEMP TABLE b_role_loadable AS
+  SELECT rm.new_id AS id, t.loaded_from_file
+  FROM role_loadable t JOIN role_map rm ON rm.old_id = t.id;
+CREATE TEMP TABLE b_role_loadable_permission AS
+  SELECT rm.new_id AS role_loadable_id, t.folio_permission, t.capability_id, t.capability_set_id,
+         t.created_by_user_id, t.created_date, t.updated_by_user_id, t.updated_date
+  FROM role_loadable_permission t JOIN role_map rm ON rm.old_id = t.role_loadable_id;
+CREATE TEMP TABLE b_policy_roles AS
+  SELECT COALESCE(pm.new_id, t.policy_id) AS policy_id,
+         COALESCE(rm.new_id, t.role_id)   AS role_id, t.required
+  FROM policy_roles t
+  LEFT JOIN policy_map pm ON pm.old_id = t.policy_id
+  LEFT JOIN role_map   rm ON rm.old_id = t.role_id
+  WHERE pm.new_id IS NOT NULL OR rm.new_id IS NOT NULL;
+CREATE TEMP TABLE b_policy_users AS
+  SELECT pm.new_id AS policy_id, t.user_id
+  FROM policy_users t JOIN policy_map pm ON pm.old_id = t.policy_id;
+
+DELETE FROM role_loadable_permission WHERE role_loadable_id IN (SELECT old_id FROM role_map);
+DELETE FROM role_loadable            WHERE id       IN (SELECT old_id FROM role_map);
+DELETE FROM user_role                WHERE role_id  IN (SELECT old_id FROM role_map);
+DELETE FROM role_capability          WHERE role_id  IN (SELECT old_id FROM role_map);
+DELETE FROM role_capability_set      WHERE role_id  IN (SELECT old_id FROM role_map);
+DELETE FROM policy_roles
+  WHERE policy_id IN (SELECT old_id FROM policy_map)
+     OR role_id   IN (SELECT old_id FROM role_map);
+DELETE FROM policy_users             WHERE policy_id IN (SELECT old_id FROM policy_map);
+
+-- If a future migration adds a table with an FK to role(id)/policy(id) not handled
+-- above, these UPDATEs fail on that FK and everything rolls back — never silent.
+UPDATE role   r SET id = m.new_id FROM role_map   m WHERE r.id = m.old_id;
+UPDATE policy p SET id = m.new_id FROM policy_map m WHERE p.id = m.old_id;
+
+UPDATE policy p
+SET name        = replace(p.name,        m.old_id::text, m.new_id::text),
+    description = replace(p.description, m.old_id::text, m.new_id::text)
+FROM role_map m
+WHERE p.name LIKE '%' || m.old_id::text || '%'
+   OR p.description LIKE '%' || m.old_id::text || '%';
+
+INSERT INTO role_loadable (id, loaded_from_file)
+  SELECT id, loaded_from_file FROM b_role_loadable;
+INSERT INTO role_loadable_permission
+  (role_loadable_id, folio_permission, capability_id, capability_set_id,
+   created_by_user_id, created_date, updated_by_user_id, updated_date)
+  SELECT * FROM b_role_loadable_permission;
+INSERT INTO user_role (role_id, user_id, created_by_user_id, created_date, updated_by_user_id, updated_date)
+  SELECT * FROM b_user_role;
+INSERT INTO role_capability (role_id, capability_id, created_by_user_id, created_date, updated_by_user_id, updated_date)
+  SELECT * FROM b_role_capability;
+INSERT INTO role_capability_set (role_id, capability_set_id, created_by_user_id, created_date, updated_by_user_id, updated_date)
+  SELECT * FROM b_role_capability_set;
+INSERT INTO policy_roles (policy_id, role_id, required)
+  SELECT * FROM b_policy_roles;
+INSERT INTO policy_users (policy_id, user_id)
+  SELECT * FROM b_policy_users;
+
+-- Every role with a same-named Keycloak role must now carry the Keycloak id.
+DO $assert$
+DECLARE bad int;
+BEGIN
+  SELECT count(*) INTO bad FROM role r
+  WHERE r.id NOT IN (SELECT id FROM kc_roles_staging)
+    AND r.name IN (SELECT name FROM kc_roles_staging);
+  IF bad > 0 THEN RAISE EXCEPTION 'ASSERT: % role(s) still have ids absent from Keycloak', bad; END IF;
+END
+$assert$;
+
+\echo '--- role id remap (name, old_id, new_id) ---'
+SELECT name, old_id, new_id FROM role_map ORDER BY name;
+\echo '--- policy id remap count ---'
+SELECT count(*) AS policies_remapped FROM policy_map;
+
+:tx_end;
+SQL
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY_RUN: FOLIO transaction rolled back; Keycloak step skipped."
+    cleanup_staging
+    log "Dry-run complete. Map preview at $MAP_CSV."
+    exit 0
+fi
+
+# ---------- Step 6: Keycloak rewrite (policy names + policy_config) -----------
+
+log "[6] Keycloak name rewrite..."
+
+run_kc <<'SQL' || die "Failed to create Keycloak staging table."
+DROP TABLE IF EXISTS role_uuid_map_staging;
+CREATE TABLE role_uuid_map_staging (old_id uuid, new_id uuid, name text);
+SQL
+run_kc -c "\copy role_uuid_map_staging (old_id, new_id, name) FROM '$MAP_CSV' WITH (FORMAT csv, HEADER true);" \
+    || die "Failed to load the role id map into Keycloak."
+
+# FOLIO is already committed here, so abort with a clear message rather than letting the
+# UNIQUE (name, resource_server_id) constraint fire mid-rewrite.
+kc_collision=$(q_kc <<'SQL'
+WITH rewritten AS (
+  SELECT rsp.resource_server_id AS rs,
+         COALESCE((SELECT replace(rsp.name, m.old_id::text, m.new_id::text)
+                   FROM role_uuid_map_staging m
+                   WHERE strpos(rsp.name, m.old_id::text) > 0 LIMIT 1), rsp.name) AS nm
+  FROM resource_server_policy rsp
+  JOIN client c ON rsp.resource_server_id = c.id
+  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
+)
+SELECT count(*) FROM (SELECT rs, nm FROM rewritten GROUP BY rs, nm HAVING count(*) > 1) d;
+SQL
+)
+[[ "$kc_collision" == "0" ]] || die "Keycloak rewrite would create $kc_collision duplicate policy name(s); FOLIO is already committed — resolve manually (see README 'Manual recovery', map: $MAP_CSV)."
+
+run_kc <<'SQL' || die "Keycloak rewrite failed; FOLIO is already committed — re-apply via README 'Manual recovery' using the saved map."
+\set ON_ERROR_STOP on
+BEGIN;
+-- psql does not interpolate :'tenant' inside the dollar-quoted DO body below;
+-- pass it via a transaction-local GUC instead.
+SELECT set_config('repair.tenant', :'tenant', true);
+
+UPDATE resource_server_policy rsp
+SET name = replace(rsp.name, m.old_id::text, m.new_id::text)
+FROM role_uuid_map_staging m
+WHERE rsp.resource_server_id IN (
+        SELECT c.id FROM client c WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant'))
+  AND strpos(rsp.name, m.old_id::text) > 0;
+
+-- policy_config 'roles' values are JSON arrays that may embed SEVERAL stale role ids,
+-- while UPDATE ... FROM applies at most one map row per target row. Loop until no row
+-- matches; a no-op when the config is already consistent.
+DO $config_remap$
+DECLARE n bigint;
+BEGIN
+  LOOP
+    UPDATE policy_config pc
+    SET value = replace(pc.value, m.old_id::text, m.new_id::text)
+    FROM role_uuid_map_staging m
+    WHERE pc.name = 'roles'
+      AND strpos(pc.value, m.old_id::text) > 0
+      AND pc.policy_id IN (
+        SELECT rsp.id FROM resource_server_policy rsp
+        JOIN client c ON rsp.resource_server_id = c.id
+        WHERE c.realm_id = (SELECT id FROM realm WHERE name = current_setting('repair.tenant')));
+    GET DIAGNOSTICS n = ROW_COUNT;
+    EXIT WHEN n = 0;
+  END LOOP;
+END
+$config_remap$;
+COMMIT;
+SQL
+
+# ---------- Step 7: Cleanup ----------------------------------------------------
+
+cleanup_staging
+log "Repair complete for tenant $TENANT. Re-run the script to verify: it must report 'Nothing to do'."
+log "Map kept at $MAP_CSV — delete it once roles are confirmed editable."
+warn "Keycloak caches authorization data in memory: perform a rolling restart of all"
+warn "Keycloak nodes OR call POST /admin/realms/$TENANT/clear-realm-cache before"
+warn "actively managing the repaired roles."

--- a/keycloak-scripts/repair-role-policy-uuids.sh
+++ b/keycloak-scripts/repair-role-policy-uuids.sh
@@ -1,21 +1,63 @@
 #!/usr/bin/env bash
-# repair-role-policy-uuids.sh — Repair role + policy UUID mapping after a realm migration
-# that regenerated Keycloak UUIDs: FOLIO's role.id / policy.id go stale and roles become
-# un-editable (404 from Keycloak). Role-and-policy counterpart of repair-policy-uuids.sh;
-# both are fixed in ONE FOLIO transaction because role ids are embedded in policy names
-# on both sides: ids are re-mapped by name BEFORE any name is rewritten.
+# repair-role-policy-uuids.sh — Re-align FOLIO mod_roles_keycloak with Keycloak after a tenant
+# realm is exported and re-imported into the SAME Keycloak cluster under a new name (the FOLIO
+# schema carried over as-is).
+#
+# WHAT BREAKS. Such a migration desynchronises up to three things by three different mechanisms.
+# Any one can occur without the others, so do not infer the whole picture from a single symptom:
+#   1. realm import  → role UUIDs regenerated (keycloak_role has a cluster-wide primary key and the
+#                      source realm still holds the old ids), leaving FOLIO's role.id stale and
+#                      roles un-editable (404 from Keycloak);
+#   2. user import   → folio user ids regenerated while Keycloak re-resolves its users by username,
+#                      so every 'Policy for user: <folio id>' name points at a user id that no
+#                      longer exists anywhere;
+#   3. policy import → policy UUIDs may be regenerated or may carry over intact. Intact ids with
+#                      stale NAME strings is a normal outcome, not a contradiction: the name embeds
+#                      an entity id, and it is the entity that moved.
+# Keycloak's own enforcement survives all three (policy_config is re-resolved on import); what
+# breaks is mod-roles-keycloak's ability to find its policies by name.
+#
+# HOW IT MATCHES. Policies are matched between FOLIO and Keycloak by a canonical ENTITY KEY, never
+# by policy name — a policy's name embeds the id of the entity it references, i.e. the very id that
+# desyncs. The key is routed by name shape and resolved from the live entity reference:
+#
+#     name shape                  key            resolved from
+#     Policy for role: <uuid>  →  role:<name>    KC: policy_config['roles'] → keycloak_role.name
+#                                                FOLIO: policy_roles.role_id → role.name
+#     Policy for user: <uuid>  →  user:<folioId> KC: policy_config['users'] → user_entity → attr 'user_id'
+#                                                FOLIO: policy_users.user_id
+#     anything else            →  name:<name>    the literal policy name (admin/TIME policies)
+#
+# Role names and folio user ids are stable across the migration, so the key matches even though the
+# ids in the names do not. Names are OUTPUT: rewritten from the maps, never a join key.
+#
+# WHAT IT SYNCHRONISES. role.id and policy.id (FOLIO adopts Keycloak's), the FOLIO child tables
+# referencing them, and every name/description string embedding a role id or folio user id on BOTH
+# sides (policies AND permissions). Anything it cannot synchronise is reported, never silently
+# skipped: unmatched policies, multi-entity or unresolvable policies, and — for the out-of-scope
+# "users were recreated" case — a hard abort (this script has no folio-user-id map source).
+#
+# WRITE ORDER — DO NOT SWAP. Keycloak is rewritten first, the FOLIO transaction commits second.
+# The two databases share no transaction, so a run can die between them; this order is what makes a
+# plain re-run sufficient. Both id maps are derived from FOLIO's ids still differing from Keycloak's,
+# and the Keycloak step rewrites only name/description STRINGS — never Keycloak ids. So after a crash
+# in between, the next run re-derives exactly the same maps and finishes. Commit FOLIO first instead
+# and the difference the maps are built from is gone, which is why that ordering needs a persisted
+# map and a resume mode. It had one; it was removed on purpose.
 #
 # Required: KC_DB_URL, FOLIO_DB_URL (postgresql://...), TENANT (realm name, e.g. "diku")
-# Optional: DRY_RUN  — "true": run the FOLIO transaction and ROLLBACK, print the report,
-#                      skip the Keycloak step entirely. Default: false.
-#           FORCE    — "true": skip (instead of abort on) roles that exist in FOLIO but
-#                      not in Keycloak. Default: false.
-#           WORK_DIR — Where the role id map CSV is persisted.
-#                      Default: /tmp/repair-role-policy-uuids-$TENANT
+# Optional: DRY_RUN — "true": skip the Keycloak rewrite, run the FOLIO transaction and ROLLBACK,
+#                     print the report. Nothing is written to either database. Default: false.
+#           FORCE   — "true": skip (instead of abort on) roles that exist in FOLIO but not Keycloak.
+#                     Default: false.
+#           WORK_DIR — Scratch space for the CSVs the run passes between the two databases; kept
+#                     afterwards for diagnosis only. Default: /tmp/repair-role-policy-uuids-$TENANT
 #
-# Production prerequisites: run in a maintenance window (the FOLIO transaction locks the
-# affected tables) and take a schema backup first:
+# Production prerequisites: run in a maintenance window (the FOLIO transaction locks the affected
+# tables) and take a schema backup first:
 #   pg_dump "$FOLIO_DB_URL" -n "${TENANT}_mod_roles_keycloak" > roles_backup.sql
+# Keycloak caches authorization data in memory: after a repair, rolling-restart all Keycloak nodes
+# OR call POST /admin/realms/$TENANT/clear-realm-cache before managing the repaired roles.
 
 set -euo pipefail
 
@@ -36,31 +78,196 @@ DRY_RUN="${DRY_RUN:-false}"
 FORCE="${FORCE:-false}"
 WORK_DIR="${WORK_DIR:-/tmp/repair-role-policy-uuids-$TENANT}"
 SCHEMA="${TENANT}_mod_roles_keycloak"
-MAP_CSV="$WORK_DIR/role_id_map.csv"
+# The maps are computed in FOLIO but applied in Keycloak; these CSVs are the transport between the
+# two connections, nothing more. They are not a recovery mechanism — a failed run is re-run.
+ROLE_MAP_CSV="$WORK_DIR/role_id_map.csv"     # old_id,new_id,name  (role UUIDs, FOLIO→KC)
+USER_MAP_CSV="$WORK_DIR/user_id_map.csv"     # old_id,new_id       (folio user ids in KC names)
+KC_LEFTOVER=0                                # set by kc_rewrite; read by the final status
 mkdir -p "$WORK_DIR"
 
-# psql wrappers. NOTE: psql does NOT interpolate :variables in `-c` strings, and \copy
-# interpolates nothing at all — statements using :'tenant'/:"schema" must go via stdin,
-# and \copy lines must have the schema expanded by bash.
+# psql wrappers. NOTE: psql does NOT interpolate :variables in `-c` strings, and \copy interpolates
+# nothing — statements using :'tenant'/:"schema" must go via stdin, and \copy lines must have the
+# schema/path expanded by bash.
 run_folio() { psql "$FOLIO_DB_URL" -v ON_ERROR_STOP=1 -v schema="$SCHEMA" -v tenant="$TENANT" "$@"; }
 run_kc()    { psql "$KC_DB_URL"    -v ON_ERROR_STOP=1 -v tenant="$TENANT" "$@"; }
 q_folio()   { run_folio -qtA "$@"; }
 q_kc()      { run_kc -qtA "$@"; }
 
+# Count Keycloak names of the form 'Policy/…​ for role|user: <id>' whose embedded id resolves to
+# neither a live realm role nor a live folio user (user_id attribute). Used twice: as work detection
+# before the run (names left pointing at entities the migration replaced) and as the leftover check
+# after the rewrite (a stale id no map covered — e.g. a user with permissions but no policy).
+kc_unresolved_count() {
+    q_kc <<'SQL'
+WITH ids AS (
+  SELECT DISTINCT substring(rsp.name FROM 'for (?:role|user):? ''?([0-9a-fA-F-]{36})') AS uid
+  FROM resource_server_policy rsp
+  JOIN client c ON rsp.resource_server_id = c.id
+  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
+    AND rsp.name ~ 'for (role|user):? '
+)
+SELECT count(*) FROM ids
+WHERE uid IS NOT NULL
+  AND uid NOT IN (SELECT id::text FROM keycloak_role
+                  WHERE realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND client_role = false)
+  AND uid NOT IN (SELECT ua.value FROM user_attribute ua JOIN user_entity ue ON ue.id = ua.user_id
+                  WHERE ua.name = 'user_id' AND ue.realm_id = (SELECT id FROM realm WHERE name = :'tenant'));
+SQL
+}
+
 cleanup_staging() {
     run_folio <<SQL || warn "Failed to drop FOLIO staging tables."
 DROP TABLE IF EXISTS :"schema".kc_roles_staging;
 DROP TABLE IF EXISTS :"schema".kc_policies_staging;
+DROP TABLE IF EXISTS :"schema".policy_key_staging;
 DROP TABLE IF EXISTS :"schema".role_id_map_staging;
+DROP TABLE IF EXISTS :"schema".kc_user_ids_staging;
 SQL
-    run_kc -c "DROP TABLE IF EXISTS role_uuid_map_staging;" >/dev/null 2>&1 || true
+    run_kc -c "DROP TABLE IF EXISTS role_uuid_map_staging; DROP TABLE IF EXISTS user_uuid_map_staging;" >/dev/null 2>&1 || true
+}
+
+# Everything this run could NOT synchronise. Called before every exit that follows classification —
+# including the "nothing to repair" ones, where silence would otherwise read as "all clear".
+# Reads the staging tables, so it must run before cleanup_staging; uses ur_total/ur_matched from
+# the pre-flight, so it must run after step 3.
+report_skipped() {
+    local skipped
+    skipped=$(q_folio <<'SQL'
+SELECT string_agg(src || ' ' || class || ' "' || name || '" [' || status || ']', chr(10) ORDER BY status, name)
+FROM (
+  SELECT 'FOLIO' AS src, class, name, status FROM :"schema".policy_key_staging  WHERE status IN ('folio_only','multi','unresolved')
+  UNION ALL
+  SELECT 'KC',    class, name, status FROM :"schema".kc_policies_staging WHERE status IN ('kc_only','multi','unresolved')
+) d;
+SQL
+) || die "Failed to collect the skipped-policy report."
+    local stale_users=""
+    if [[ "$ur_matched" != "$ur_total" ]]; then
+        stale_users=$(q_folio <<'SQL'
+SELECT string_agg(DISTINCT ur.user_id::text, chr(10))
+FROM :"schema".user_role ur
+LEFT JOIN :"schema".kc_user_ids_staging k ON k.folio_user_id = ur.user_id
+WHERE k.folio_user_id IS NULL;
+SQL
+) || die "Failed to collect the stale user-link report."
+    fi
+    if [[ -n "$skipped" || -n "$stale_users" ]]; then
+        warn "Could not synchronise (reported, not repaired):"
+        [[ -n "$skipped" ]] && printf '%s\n' "$skipped" >&2
+        [[ -n "$stale_users" ]] && warn "FOLIO user_role.user_id not known to Keycloak (stale user link):" && printf '%s\n' "$stale_users" >&2
+        warn "(Anything created after the Keycloak export also lands here; re-run to confirm it is genuine.)"
+    else
+        log "Could not synchronise: nothing — every policy on both sides found its counterpart."
+    fi
+}
+
+# ==========================================================================================
+# Keycloak string rewrite (step 6, the FIRST of the two writes). Rewrites resource_server_policy
+# name + description and policy_config['roles'] from the two map CSVs. Idempotent: it substitutes
+# old ids that are no longer present after a first pass, so a repeat is a no-op.
+# ==========================================================================================
+kc_rewrite() {
+    log "[6] Keycloak name/description rewrite..."
+
+    run_kc <<'SQL' || die "Failed to create Keycloak staging tables."
+DROP TABLE IF EXISTS role_uuid_map_staging;
+DROP TABLE IF EXISTS user_uuid_map_staging;
+CREATE TABLE role_uuid_map_staging (old_id uuid, new_id uuid, name text);
+CREATE TABLE user_uuid_map_staging (old_id uuid, new_id uuid);
+SQL
+    run_kc -c "\copy role_uuid_map_staging (old_id, new_id, name) FROM '$ROLE_MAP_CSV' WITH (FORMAT csv, HEADER true);" \
+        || die "Failed to load the role id map into Keycloak."
+    run_kc -c "\copy user_uuid_map_staging (old_id, new_id) FROM '$USER_MAP_CSV' WITH (FORMAT csv, HEADER true);" \
+        || die "Failed to load the user id map into Keycloak."
+
+    # Empty maps mean nothing embeds a stale id in Keycloak (only FOLIO ids had drifted, or the names
+    # were already current) — a legitimate no-op, not an error.
+    local map_rows
+    map_rows=$(q_kc -c "SELECT (SELECT count(*) FROM role_uuid_map_staging) + (SELECT count(*) FROM user_uuid_map_staging);")
+    if [[ "${map_rows:-0}" == "0" ]]; then
+        log "No Keycloak-side rewrite needed (maps are empty)."
+        KC_LEFTOVER="$(kc_unresolved_count)"; KC_LEFTOVER="${KC_LEFTOVER:-0}"
+        return 0
+    fi
+
+    # Abort cleanly rather than letting the UNIQUE (name, resource_server_id) constraint fire
+    # mid-rewrite. Nothing has been written to either database at this point.
+    local collision
+    collision=$(q_kc <<'SQL'
+WITH m AS (
+  SELECT old_id::text AS old_id, new_id::text AS new_id FROM role_uuid_map_staging
+  UNION ALL
+  SELECT old_id::text, new_id::text FROM user_uuid_map_staging),
+rewritten AS (
+  SELECT rsp.resource_server_id AS rs,
+         COALESCE((SELECT replace(rsp.name, m.old_id, m.new_id) FROM m
+                   WHERE strpos(rsp.name, m.old_id) > 0 LIMIT 1), rsp.name) AS nm
+  FROM resource_server_policy rsp
+  JOIN client c ON rsp.resource_server_id = c.id
+  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant'))
+SELECT count(*) FROM (SELECT rs, nm FROM rewritten GROUP BY rs, nm HAVING count(*) > 1) d;
+SQL
+)
+    [[ "$collision" == "0" ]] || die "Keycloak rewrite would create $collision duplicate policy name(s). Nothing was written; resolve the duplicate names in Keycloak (maps for reference in $WORK_DIR) and re-run."
+
+    run_kc <<'SQL' || die "Keycloak rewrite failed; it is a single transaction, so nothing was written. Fix the cause and re-run."
+\set ON_ERROR_STOP on
+BEGIN;
+-- psql does not interpolate :'tenant' inside the dollar-quoted DO body below; pass it via a
+-- transaction-local GUC instead.
+SELECT set_config('repair.tenant', :'tenant', true);
+
+-- Names + descriptions embedding a role id (policies and 'access for role ...' permissions) and a
+-- folio user id (policies and 'access for user ...' permissions). Both maps, one pass each: every
+-- target is a resource_server_policy row, so substring substitution covers all of them.
+UPDATE resource_server_policy rsp
+SET name        = replace(rsp.name,        m.old_id::text, m.new_id::text),
+    description = replace(coalesce(rsp.description, ''), m.old_id::text, m.new_id::text)
+FROM (SELECT old_id, new_id FROM role_uuid_map_staging
+      UNION ALL SELECT old_id, new_id FROM user_uuid_map_staging) m
+WHERE rsp.resource_server_id IN (
+        SELECT c.id FROM client c WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant'))
+  AND (strpos(rsp.name, m.old_id::text) > 0 OR strpos(coalesce(rsp.description,''), m.old_id::text) > 0);
+
+-- policy_config 'roles' values are JSON arrays that may embed SEVERAL stale role ids, while
+-- UPDATE ... FROM applies at most one map row per target row. Loop until no row matches (capped, so
+-- a swapped map cannot spin forever). user policy_config['users'] holds internal KC user_entity.id,
+-- which the import re-resolved — it is already correct and NOT a rewrite target.
+DO $config_remap$
+DECLARE n bigint; guard int := 0;
+BEGIN
+  LOOP
+    UPDATE policy_config pc
+    SET value = replace(pc.value, m.old_id::text, m.new_id::text)
+    FROM role_uuid_map_staging m
+    WHERE pc.name = 'roles'
+      AND strpos(pc.value, m.old_id::text) > 0
+      AND pc.policy_id IN (
+        SELECT rsp.id FROM resource_server_policy rsp
+        JOIN client c ON rsp.resource_server_id = c.id
+        WHERE c.realm_id = (SELECT id FROM realm WHERE name = current_setting('repair.tenant')));
+    GET DIAGNOSTICS n = ROW_COUNT;
+    guard := guard + 1;
+    EXIT WHEN n = 0;
+    IF guard > 100 THEN RAISE EXCEPTION 'policy_config remap did not converge in 100 passes (map has a chain or swap)'; END IF;
+  END LOOP;
+END
+$config_remap$;
+COMMIT;
+SQL
+
+    # Leftover check: after all rewrites, any name still embedding an id that resolves to no live
+    # entity is a stale id no map covered (e.g. a user with permissions but no policy). Reported, not
+    # fatal, but the run ends on a WARN, not "complete".
+    KC_LEFTOVER="$(kc_unresolved_count)"
+    KC_LEFTOVER="${KC_LEFTOVER:-0}"
 }
 
 log "tenant=$TENANT schema=$SCHEMA dry_run=$DRY_RUN force=$FORCE work_dir=$WORK_DIR"
 
-# ---------- Step 1: Export current roles and policies from Keycloak ----------
+# ---------- Step 1: Export current roles, policies and user ids from Keycloak ----------
 
-log "[1] Exporting Keycloak realm roles and policies..."
+log "[1] Exporting Keycloak realm roles, policies and user ids..."
 
 echo "SELECT 1 FROM realm WHERE name = :'tenant';" | q_kc | grep -q 1 \
     || die "Realm '$TENANT' not found in Keycloak."
@@ -74,33 +281,123 @@ COPY (
 ) TO STDOUT WITH (FORMAT csv, HEADER true);
 SQL
 
+# Policies restricted to the match set (role/user/time); scope/resource/client policies are not
+# match candidates — they are rewrite targets only. Per policy we emit the canonical key plus refs
+# (how many entities it references), which drives the multi-entity classification; an entity that
+# does not resolve contributes no name, leaving the key empty. Config shapes differ:
+#   roles  → [{"id":"<roleId>","required":false}, ...]   (array of objects)
+#   users  → ["<user_entity.id>", ...]                    (array of scalars)
 q_kc <<'SQL' > "$WORK_DIR/kc_policies.csv" || die "Failed to export Keycloak policies."
 COPY (
-    SELECT rsp.id, rsp.name
+  WITH pol AS (
+    SELECT rsp.id, rsp.name, rsp.type
     FROM resource_server_policy rsp
     JOIN client c ON rsp.resource_server_id = c.id
     WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
+      AND rsp.type IN ('role','user','time')
+  ),
+  role_ref AS (   -- role policies: config['roles'] -> keycloak_role.name
+    SELECT p.id, count(*) AS refs, min(kr.name) AS ent
+    FROM pol p
+    JOIN policy_config pc ON pc.policy_id = p.id AND pc.name = 'roles' AND pc.value LIKE '[%'
+    CROSS JOIN LATERAL json_array_elements(pc.value::json) e
+    LEFT JOIN keycloak_role kr ON kr.id = (e->>'id')
+      AND kr.realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND kr.client_role = false
+    WHERE p.name LIKE 'Policy for role: %'
+    GROUP BY p.id
+  ),
+  user_ref AS (   -- user policies: config['users'] -> user_entity.id -> attr 'user_id' (folio id)
+    -- count DISTINCT e, not rows: a user carrying two 'user_id' attribute rows would otherwise
+    -- inflate refs to 2 and get the policy written off as multi-entity. (The role branch above
+    -- joins on a primary key, so count(*) is already one row per referenced entity there — and
+    -- DISTINCT is not even available on it, json having no equality operator.)
+    SELECT p.id, count(DISTINCT e) AS refs, min(ua.value) AS ent
+    FROM pol p
+    JOIN policy_config pc ON pc.policy_id = p.id AND pc.name = 'users' AND pc.value LIKE '[%'
+    CROSS JOIN LATERAL json_array_elements_text(pc.value::json) e
+    LEFT JOIN user_attribute ua ON ua.user_id = e AND ua.name = 'user_id'
+    WHERE p.name LIKE 'Policy for user: %'
+    GROUP BY p.id
+  )
+  SELECT p.id, p.name, p.type AS class,
+         COALESCE(rr.refs, ur.refs, 0) AS refs,
+         CASE
+           WHEN p.name LIKE 'Policy for role: %' THEN 'role:' || COALESCE(rr.ent, '')
+           WHEN p.name LIKE 'Policy for user: %' THEN 'user:' || COALESCE(ur.ent, '')
+           ELSE 'name:' || p.name
+         END AS key
+  FROM pol p
+  LEFT JOIN role_ref rr ON rr.id = p.id
+  LEFT JOIN user_ref ur ON ur.id = p.id
 ) TO STDOUT WITH (FORMAT csv, HEADER true);
 SQL
 
-# ---------- Step 2: Stage the export in FOLIO and build the role map ---------
+# All folio user ids Keycloak knows (via the user_id attribute), for the §4 user-link check.
+q_kc <<'SQL' > "$WORK_DIR/kc_user_ids.csv" || die "Failed to export Keycloak user ids."
+COPY (
+    SELECT DISTINCT ua.value AS folio_user_id
+    FROM user_attribute ua
+    JOIN user_entity ue ON ue.id = ua.user_id
+    WHERE ua.name = 'user_id'
+      AND ue.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
+) TO STDOUT WITH (FORMAT csv, HEADER true);
+SQL
 
-log "[2] Staging Keycloak export in FOLIO..."
+# ---------- Step 2: Stage the export in FOLIO, build maps, classify ----------
+
+log "[2] Staging Keycloak export in FOLIO and classifying..."
 
 run_folio <<'SQL' || die "Failed to create staging tables."
 DROP TABLE IF EXISTS :"schema".kc_roles_staging;
 DROP TABLE IF EXISTS :"schema".kc_policies_staging;
+DROP TABLE IF EXISTS :"schema".policy_key_staging;
 DROP TABLE IF EXISTS :"schema".role_id_map_staging;
-CREATE TABLE :"schema".kc_roles_staging   (id uuid, name text);
-CREATE TABLE :"schema".kc_policies_staging (id uuid, name text);
+DROP TABLE IF EXISTS :"schema".kc_user_ids_staging;
+CREATE TABLE :"schema".kc_roles_staging    (id uuid, name text);
+CREATE TABLE :"schema".kc_policies_staging (id uuid, name text, class text, refs int, key text, status text);
+CREATE TABLE :"schema".policy_key_staging  (id uuid, name text, class text, refs int, key text, status text);
 CREATE TABLE :"schema".role_id_map_staging (old_id uuid, new_id uuid, name text);
+CREATE TABLE :"schema".kc_user_ids_staging (folio_user_id uuid);
 SQL
 
 run_folio <<SQL || die "Failed to load staging tables."
 \\copy ${SCHEMA}.kc_roles_staging (id, name) FROM '$WORK_DIR/kc_roles.csv' WITH (FORMAT csv, HEADER true)
-\\copy ${SCHEMA}.kc_policies_staging (id, name) FROM '$WORK_DIR/kc_policies.csv' WITH (FORMAT csv, HEADER true)
+\\copy ${SCHEMA}.kc_policies_staging (id, name, class, refs, key) FROM '$WORK_DIR/kc_policies.csv' WITH (FORMAT csv, HEADER true)
+\\copy ${SCHEMA}.kc_user_ids_staging (folio_user_id) FROM '$WORK_DIR/kc_user_ids.csv' WITH (FORMAT csv, HEADER true)
 SQL
 
+# FOLIO-side key staging, same shape and same name-shape classifier as the KC export.
+run_folio <<'SQL' || die "Failed to build FOLIO key staging."
+INSERT INTO :"schema".policy_key_staging (id, name, class, refs, key)
+WITH pol AS (
+  SELECT p.id, p.name, p.type::text AS type
+  FROM :"schema".policy p
+  WHERE p.type IN ('ROLE','USER','TIME')
+),
+role_ref AS (
+  SELECT pr.policy_id AS id, count(*) AS refs, min(r.name) AS ent
+  FROM :"schema".policy_roles pr
+  LEFT JOIN :"schema".role r ON r.id = pr.role_id
+  GROUP BY pr.policy_id
+),
+user_ref AS (
+  SELECT pu.policy_id AS id, count(*) AS refs, min(pu.user_id::text) AS ent
+  FROM :"schema".policy_users pu
+  GROUP BY pu.policy_id
+)
+SELECT p.id, p.name, p.type,
+       COALESCE(rr.refs, ur.refs, 0),
+       CASE
+         WHEN p.name LIKE 'Policy for role: %' THEN 'role:' || COALESCE(rr.ent, '')
+         WHEN p.name LIKE 'Policy for user: %' THEN 'user:' || COALESCE(ur.ent, '')
+         ELSE 'name:' || p.name
+       END
+FROM pol p
+LEFT JOIN role_ref rr ON rr.id = p.id
+LEFT JOIN user_ref ur ON ur.id = p.id;
+SQL
+
+# Role id map: same-named roles whose ids differ. Role NAME is the stable key.
 run_folio <<'SQL' || die "Failed to build the role id map."
 INSERT INTO :"schema".role_id_map_staging (old_id, new_id, name)
 SELECT r.id, k.id, r.name
@@ -109,12 +406,41 @@ JOIN :"schema".kc_roles_staging k ON k.name = r.name
 WHERE r.id IS DISTINCT FROM k.id;
 SQL
 
-# ---------- Step 3: Pre-flight checks -----------------------------------------
+# Status, computed once on both staging tables (read everywhere downstream):
+#   multi       refs > 1                       (key is not 1:1 — cannot repair safely)
+#   unresolved  key is 'role:' / 'user:' bare  (the referenced entity contributed no name)
+#   candidate → matched | folio_only | kc_only  by cross-side key
+# The unresolved test is on the KEY, not on a count, because an empty key is exactly what makes a
+# policy unmatchable — and a bare 'role:' would otherwise collide with every other bare 'role:'.
+# It covers a policy referencing nothing at all as well as one whose reference this script cannot
+# follow: a KC role policy over a CLIENT role resolves to no name here, because the join is
+# restricted to realm roles. Name-shaped keys ('name:<policy name>') legitimately carry refs = 0.
+# Known asymmetry: refs counts the entity reference only for 'Policy for role|user:'-shaped names;
+# a custom-named admin policy over several roles is 'multi' on the FOLIO side (which counts
+# policy_roles regardless of name) but keyed by name → 'kc_only' on the KC side. Both are skipped and
+# reported, so it is safe — just not symmetric.
+run_folio <<'SQL' || die "Failed to classify staged policies."
+UPDATE :"schema".kc_policies_staging SET status =
+  CASE WHEN refs > 1 THEN 'multi' WHEN key IN ('role:','user:') THEN 'unresolved' ELSE 'candidate' END;
+UPDATE :"schema".policy_key_staging SET status =
+  CASE WHEN refs > 1 THEN 'multi' WHEN key IN ('role:','user:') THEN 'unresolved' ELSE 'candidate' END;
+
+UPDATE :"schema".policy_key_staging f SET status = 'matched'
+WHERE f.status = 'candidate'
+  AND f.key IN (SELECT key FROM :"schema".kc_policies_staging WHERE status = 'candidate');
+UPDATE :"schema".kc_policies_staging k SET status = 'matched'
+WHERE k.status = 'candidate'
+  AND k.key IN (SELECT key FROM :"schema".policy_key_staging WHERE status = 'matched');
+UPDATE :"schema".policy_key_staging SET status = 'folio_only' WHERE status = 'candidate';
+UPDATE :"schema".kc_policies_staging SET status = 'kc_only'   WHERE status = 'candidate';
+SQL
+
+# ---------- Step 3: Pre-flight checks ----------
 
 log "[3] Pre-flight checks..."
 
-# Hard-coded reinsert column lists MUST match the live schema: an incomplete list would
-# silently NULL/reset columns on reinsert (DEFAULT columns do not error). Abort on drift.
+# Hard-coded reinsert column lists MUST match the live schema: an incomplete list would silently
+# NULL/reset columns on reinsert (DEFAULT columns do not error). Abort on drift.
 col_mismatch=$(q_folio <<'SQL'
 WITH expected(tbl, cols) AS (
   VALUES
@@ -143,77 +469,118 @@ SQL
 [[ -z "$col_mismatch" ]] || die "Schema drift detected; fix the script's column lists before running:
 $col_mismatch"
 
-# Names are the mapping keys — duplicates would make the repair non-deterministic.
-dup_roles=$(echo 'SELECT string_agg(name, chr(44)) FROM (SELECT name FROM :"schema".kc_roles_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio)
+# Duplicate role names would make the role map non-deterministic.
+dup_roles=$(echo 'SELECT string_agg(name, chr(44) ORDER BY name) FROM (SELECT name FROM :"schema".kc_roles_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio)
 [[ -z "$dup_roles" ]] || die "Duplicate realm role names in Keycloak (cannot map by name): $dup_roles"
-dup_policies=$(echo 'SELECT string_agg(name, chr(44)) FROM (SELECT name FROM :"schema".kc_policies_staging GROUP BY name HAVING count(*) > 1) d;' | q_folio)
-[[ -z "$dup_policies" ]] || die "Duplicate policy names across Keycloak resource servers (cannot map by name): $dup_policies"
 
-folio_only=$(q_folio <<'SQL'
-SELECT string_agg(r.name || ' (' || r.id || ')', ', ')
+# ABORT 1: duplicate effective key among match-eligible policies (either side). A duplicate key
+# fans out the id UPDATE non-deterministically. Report the keys and stop.
+dup_keys=$(q_folio <<'SQL'
+SELECT string_agg(src || ':' || key, chr(44) ORDER BY key) FROM (
+  SELECT 'FOLIO' AS src, key FROM :"schema".policy_key_staging  WHERE status = 'matched' GROUP BY key HAVING count(*) > 1
+  UNION ALL
+  SELECT 'KC',    key FROM :"schema".kc_policies_staging WHERE status = 'matched' GROUP BY key HAVING count(*) > 1
+) d;
+SQL
+)
+[[ -z "$dup_keys" ]] || die "Duplicate effective policy key(s) — cannot map deterministically: $dup_keys"
+
+# ABORT 2: user link broken (out-of-scope "users recreated" migration). If NONE of FOLIO's
+# user_role.user_id values is known to Keycloak as a user_id attribute, folio user ids were
+# regenerated and this script has no map source for them — abort. A partial overlap is repaired
+# where possible; the stale rows are enumerated in the report (see below), never silently passed.
+IFS='|' read -r ur_total ur_matched < <(q_folio <<'SQL'
+SELECT count(DISTINCT ur.user_id),
+       count(DISTINCT ur.user_id) FILTER (WHERE k.folio_user_id IS NOT NULL)
+FROM :"schema".user_role ur
+LEFT JOIN :"schema".kc_user_ids_staging k ON k.folio_user_id = ur.user_id;
+SQL
+)
+ur_total="${ur_total:-0}"; ur_matched="${ur_matched:-0}"
+# Zero overlap is only evidence of regenerated user ids when there are enough rows for it to mean
+# something: on a nearly empty tenant the one or two users present may simply not be provisioned in
+# Keycloak yet (created in FOLIO, not yet synced), and aborting the whole repair over that would be
+# wrong. Below the sample size the mismatched rows still surface in the skipped report.
+USER_LINK_MIN_SAMPLE=3
+if [[ "$ur_total" -ge "$USER_LINK_MIN_SAMPLE" && "$ur_matched" == "0" ]]; then
+    die "User link broken: none of $ur_total FOLIO user_role.user_id values is known to Keycloak (user_id attribute). Folio user ids were regenerated — this migration ('users recreated') is out of scope; repair user provisioning first."
+fi
+
+# ABORT 3: roles present in FOLIO but not Keycloak (existing guard).
+folio_only_roles=$(q_folio <<'SQL'
+SELECT string_agg(r.name || ' (' || r.id || ')', ', ' ORDER BY r.name)
 FROM :"schema".role r LEFT JOIN :"schema".kc_roles_staging k ON k.name = r.name
 WHERE k.id IS NULL;
 SQL
 )
-if [[ -n "$folio_only" ]]; then
+if [[ -n "$folio_only_roles" ]]; then
     if [[ "$FORCE" == "true" ]]; then
-        warn "Roles present in FOLIO but not in Keycloak (FORCE => skipped, NOT repaired): $folio_only"
+        warn "Roles present in FOLIO but not in Keycloak (FORCE => skipped, NOT repaired): $folio_only_roles"
     else
-        die "Roles present in FOLIO but not in Keycloak (set FORCE=true to skip them): $folio_only"
+        die "Roles present in FOLIO but not in Keycloak (set FORCE=true to skip them): $folio_only_roles"
     fi
 fi
 
-# Work detection: role/policy id drift + stale role ids embedded in names (either side).
+# ---------- Step 4: Work detection ----------
+
+# Three independent classes of work: drifted role ids, drifted policy ids among matched entities, and
+# names still embedding an id that resolves to nothing. Any one of them alone is a real repair — a
+# migration can regenerate folio user ids without moving a single policy id, which leaves nothing but
+# stale name strings.
 role_diff=$(echo 'SELECT count(*) FROM :"schema".role_id_map_staging;' | q_folio)
 policy_diff=$(q_folio <<'SQL'
-SELECT count(*) FROM :"schema".policy p
-JOIN :"schema".kc_policies_staging k ON k.name = p.name
-WHERE p.id IS DISTINCT FROM k.id;
+SELECT count(*) FROM :"schema".policy_key_staging f
+JOIN :"schema".kc_policies_staging k ON k.key = f.key AND k.status = 'matched'
+WHERE f.status = 'matched' AND f.id IS DISTINCT FROM k.id;
 SQL
 )
-folio_stale=$(q_folio <<'SQL'
-SET search_path TO :"schema";
-SELECT count(*) FROM policy
-WHERE name LIKE 'Policy for role: %'
-  AND substring(name FROM 'Policy for role: (.*)$') NOT IN (SELECT id::text FROM role);
-SQL
-)
-kc_stale=$(q_kc <<'SQL'
-WITH ids AS (
-  SELECT DISTINCT substring(rsp.name FROM 'for role:? ''?([0-9a-fA-F-]{36})') AS uid
-  FROM resource_server_policy rsp
-  JOIN client c ON rsp.resource_server_id = c.id
-  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
-    AND (rsp.name LIKE 'Policy for role: %' OR rsp.name LIKE '% access for role %')
-)
-SELECT count(*) FROM ids
-WHERE uid IS NOT NULL AND uid NOT IN (
-  SELECT id::text FROM keycloak_role
-  WHERE realm_id = (SELECT id FROM realm WHERE name = :'tenant') AND client_role = false);
-SQL
-)
-log "    role id mismatches: $role_diff, policy id mismatches: $policy_diff, stale names: FOLIO=$folio_stale KC=$kc_stale"
+kc_stale=$(kc_unresolved_count)
+log "    role id mismatches: $role_diff, policy id mismatches: $policy_diff, stale KC names: $kc_stale"
 
-if [[ "$role_diff" == "0" && "$policy_diff" == "0" ]]; then
-    if [[ "$folio_stale" == "0" && "$kc_stale" == "0" ]]; then
-        log "Nothing to do: FOLIO ids already match Keycloak and no stale names. Exiting."
-        cleanup_staging
-        exit 0
-    fi
-    die "Ids match but stale names remain (FOLIO=$folio_stale, KC=$kc_stale) — a previous run likely failed between the FOLIO commit and the Keycloak step. See 'Manual recovery' in README.md (uses $MAP_CSV from that run)."
+# Everything this run cannot synchronise, reported once, before either database is written — so it
+# is on the operator's screen whichever way the run ends. It reads only the staging tables, which
+# neither write touches, so the content is the same wherever it is called.
+report_skipped
+
+if [[ "$role_diff" == "0" && "$policy_diff" == "0" && "$kc_stale" == "0" ]]; then
+    log "Nothing to repair: FOLIO ids already match Keycloak and no name embeds a dead id."
+    cleanup_staging
+    exit 0
 fi
 
-# ---------- Step 4: Persist the role id map (recovery key) --------------------
+# ---------- Step 5: Write the map CSVs (transport into the Keycloak connection) ----------
 
-echo 'COPY (SELECT old_id, new_id, name FROM :"schema".role_id_map_staging) TO STDOUT WITH (FORMAT csv, HEADER true);' \
-    | q_folio > "$MAP_CSV" || die "Failed to write role id map."
-log "[4] Role id map written to $MAP_CSV"
+echo 'COPY (SELECT old_id, new_id, name FROM :"schema".role_id_map_staging ORDER BY name) TO STDOUT WITH (FORMAT csv, HEADER true);' \
+    | q_folio > "$ROLE_MAP_CSV" || die "Failed to write role id map."
 
-# ---------- Step 5: FOLIO transaction (id fix + name rewrite) -----------------
+# User map for the Keycloak rewrite: for each matched user policy, the folio user id embedded in the
+# KC name (stale) → FOLIO's policy_users.user_id (current). Empty when KC names are already current.
+q_folio <<'SQL' > "$USER_MAP_CSV" || die "Failed to write user id map."
+COPY (
+  SELECT DISTINCT substring(k.name FROM 'Policy for user: ([0-9a-fA-F-]{36})') AS old_id,
+         pu.user_id AS new_id
+  FROM :"schema".kc_policies_staging k
+  JOIN :"schema".policy_key_staging f ON f.key = k.key AND f.status = 'matched'
+  JOIN :"schema".policy_users pu ON pu.policy_id = f.id
+  WHERE k.status = 'matched' AND k.key LIKE 'user:%'
+    AND substring(k.name FROM 'Policy for user: ([0-9a-fA-F-]{36})') IS DISTINCT FROM pu.user_id::text
+) TO STDOUT WITH (FORMAT csv, HEADER true);
+SQL
+log "[5] Maps written to $WORK_DIR (role_id_map.csv, user_id_map.csv)"
+
+# ---------- Step 6: Keycloak rewrite — the FIRST write. See the WRITE ORDER note at the top. ----------
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    log "[6] DRY_RUN: skipping the Keycloak rewrite (nothing is written to Keycloak)."
+else
+    kc_rewrite
+fi
+
+# ---------- Step 7: FOLIO transaction (id fix + name rewrite) — the SECOND write ----------
 
 tx_end="COMMIT"
 [[ "$DRY_RUN" == "true" ]] && tx_end="ROLLBACK"
-log "[5] FOLIO transaction (end=$tx_end)..."
+log "[7] FOLIO transaction (end=$tx_end)..."
 
 run_folio -v tx_end="$tx_end" <<'SQL' || die "FOLIO transaction failed (rolled back)."
 \set ON_ERROR_STOP on
@@ -225,13 +592,24 @@ LOCK TABLE role, policy, user_role, role_capability, role_capability_set,
            role_loadable, role_loadable_permission, policy_roles, policy_users
 IN EXCLUSIVE MODE;
 
--- Maps must be built while names still embed the OLD role ids on both sides.
+-- Maps built while names still embed the OLD ids. policy_map: matched policies whose ids differ.
 CREATE TEMP TABLE role_map AS
   SELECT old_id, new_id, name FROM role_id_map_staging;
 CREATE TEMP TABLE policy_map AS
-  SELECT p.id AS old_id, k.id AS new_id, p.name
-  FROM policy p JOIN kc_policies_staging k ON k.name = p.name
-  WHERE p.id IS DISTINCT FROM k.id;
+  SELECT f.id AS old_id, k.id AS new_id
+  FROM policy_key_staging f
+  JOIN kc_policies_staging k ON k.key = f.key AND k.status = 'matched'
+  WHERE f.status = 'matched' AND f.id IS DISTINCT FROM k.id;
+-- FOLIO-side user map: folio user id embedded in a matched user policy's FOLIO name (if stale)
+-- → policy_users.user_id. Empty in the carry-over case (FOLIO names are already current); present
+-- only if a FOLIO user-policy name disagrees with its policy_users row.
+CREATE TEMP TABLE user_map AS
+  SELECT DISTINCT substring(f.name FROM 'Policy for user: ([0-9a-fA-F-]{36})') AS old_id,
+         pu.user_id::text AS new_id
+  FROM policy_key_staging f
+  JOIN policy_users pu ON pu.policy_id = f.id
+  WHERE f.status = 'matched' AND f.key LIKE 'user:%'
+    AND substring(f.name FROM 'Policy for user: ([0-9a-fA-F-]{36})') IS DISTINCT FROM pu.user_id::text;
 
 -- Capture children with NEW ids substituted, then delete/update/reinsert: no FK is
 -- ON UPDATE CASCADE or deferrable, and role_loadable is ON DELETE RESTRICT.
@@ -272,17 +650,26 @@ DELETE FROM policy_roles
      OR role_id   IN (SELECT old_id FROM role_map);
 DELETE FROM policy_users             WHERE policy_id IN (SELECT old_id FROM policy_map);
 
--- If a future migration adds a table with an FK to role(id)/policy(id) not handled
--- above, these UPDATEs fail on that FK and everything rolls back — never silent.
+-- If a future migration adds a table with an FK to role(id)/policy(id) not handled above, these
+-- UPDATEs fail on that FK and everything rolls back — never silent.
 UPDATE role   r SET id = m.new_id FROM role_map   m WHERE r.id = m.old_id;
 UPDATE policy p SET id = m.new_id FROM policy_map m WHERE p.id = m.old_id;
 
+-- Names/descriptions embedding an OLD role id (role policies + descriptions).
 UPDATE policy p
 SET name        = replace(p.name,        m.old_id::text, m.new_id::text),
-    description = replace(p.description, m.old_id::text, m.new_id::text)
+    description = replace(coalesce(p.description, ''), m.old_id::text, m.new_id::text)
 FROM role_map m
 WHERE p.name LIKE '%' || m.old_id::text || '%'
-   OR p.description LIKE '%' || m.old_id::text || '%';
+   OR coalesce(p.description,'') LIKE '%' || m.old_id::text || '%';
+-- Names/descriptions embedding an OLD folio user id (matched user policies only; no-op when the
+-- FOLIO name already holds policy_users.user_id, which is the carry-over case).
+UPDATE policy p
+SET name        = replace(p.name,        m.old_id, m.new_id),
+    description = replace(coalesce(p.description, ''), m.old_id, m.new_id)
+FROM user_map m
+WHERE p.name LIKE '%' || m.old_id || '%'
+   OR coalesce(p.description,'') LIKE '%' || m.old_id || '%';
 
 INSERT INTO role_loadable (id, loaded_from_file)
   SELECT id, loaded_from_file FROM b_role_loadable;
@@ -314,90 +701,28 @@ $assert$;
 
 \echo '--- role id remap (name, old_id, new_id) ---'
 SELECT name, old_id, new_id FROM role_map ORDER BY name;
-\echo '--- policy id remap count ---'
+\echo '--- per-class policy summary (class, status, count) ---'
+SELECT class, status, count(*) FROM policy_key_staging GROUP BY 1,2 ORDER BY 1,2;
+\echo '--- policies whose id was remapped ---'
 SELECT count(*) AS policies_remapped FROM policy_map;
 
 :tx_end;
 SQL
 
+# ---------- Step 8: Cleanup + final status ----------
+
 if [[ "$DRY_RUN" == "true" ]]; then
-    log "DRY_RUN: FOLIO transaction rolled back; Keycloak step skipped."
     cleanup_staging
-    log "Dry-run complete. Map preview at $MAP_CSV."
+    log "Dry-run complete: Keycloak untouched, FOLIO transaction rolled back. Maps preview in $WORK_DIR."
     exit 0
 fi
 
-# ---------- Step 6: Keycloak rewrite (policy names + policy_config) -----------
-
-log "[6] Keycloak name rewrite..."
-
-run_kc <<'SQL' || die "Failed to create Keycloak staging table."
-DROP TABLE IF EXISTS role_uuid_map_staging;
-CREATE TABLE role_uuid_map_staging (old_id uuid, new_id uuid, name text);
-SQL
-run_kc -c "\copy role_uuid_map_staging (old_id, new_id, name) FROM '$MAP_CSV' WITH (FORMAT csv, HEADER true);" \
-    || die "Failed to load the role id map into Keycloak."
-
-# FOLIO is already committed here, so abort with a clear message rather than letting the
-# UNIQUE (name, resource_server_id) constraint fire mid-rewrite.
-kc_collision=$(q_kc <<'SQL'
-WITH rewritten AS (
-  SELECT rsp.resource_server_id AS rs,
-         COALESCE((SELECT replace(rsp.name, m.old_id::text, m.new_id::text)
-                   FROM role_uuid_map_staging m
-                   WHERE strpos(rsp.name, m.old_id::text) > 0 LIMIT 1), rsp.name) AS nm
-  FROM resource_server_policy rsp
-  JOIN client c ON rsp.resource_server_id = c.id
-  WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant')
-)
-SELECT count(*) FROM (SELECT rs, nm FROM rewritten GROUP BY rs, nm HAVING count(*) > 1) d;
-SQL
-)
-[[ "$kc_collision" == "0" ]] || die "Keycloak rewrite would create $kc_collision duplicate policy name(s); FOLIO is already committed — resolve manually (see README 'Manual recovery', map: $MAP_CSV)."
-
-run_kc <<'SQL' || die "Keycloak rewrite failed; FOLIO is already committed — re-apply via README 'Manual recovery' using the saved map."
-\set ON_ERROR_STOP on
-BEGIN;
--- psql does not interpolate :'tenant' inside the dollar-quoted DO body below;
--- pass it via a transaction-local GUC instead.
-SELECT set_config('repair.tenant', :'tenant', true);
-
-UPDATE resource_server_policy rsp
-SET name = replace(rsp.name, m.old_id::text, m.new_id::text)
-FROM role_uuid_map_staging m
-WHERE rsp.resource_server_id IN (
-        SELECT c.id FROM client c WHERE c.realm_id = (SELECT id FROM realm WHERE name = :'tenant'))
-  AND strpos(rsp.name, m.old_id::text) > 0;
-
--- policy_config 'roles' values are JSON arrays that may embed SEVERAL stale role ids,
--- while UPDATE ... FROM applies at most one map row per target row. Loop until no row
--- matches; a no-op when the config is already consistent.
-DO $config_remap$
-DECLARE n bigint;
-BEGIN
-  LOOP
-    UPDATE policy_config pc
-    SET value = replace(pc.value, m.old_id::text, m.new_id::text)
-    FROM role_uuid_map_staging m
-    WHERE pc.name = 'roles'
-      AND strpos(pc.value, m.old_id::text) > 0
-      AND pc.policy_id IN (
-        SELECT rsp.id FROM resource_server_policy rsp
-        JOIN client c ON rsp.resource_server_id = c.id
-        WHERE c.realm_id = (SELECT id FROM realm WHERE name = current_setting('repair.tenant')));
-    GET DIAGNOSTICS n = ROW_COUNT;
-    EXIT WHEN n = 0;
-  END LOOP;
-END
-$config_remap$;
-COMMIT;
-SQL
-
-# ---------- Step 7: Cleanup ----------------------------------------------------
-
 cleanup_staging
-log "Repair complete for tenant $TENANT. Re-run the script to verify: it must report 'Nothing to do'."
-log "Map kept at $MAP_CSV — delete it once roles are confirmed editable."
-warn "Keycloak caches authorization data in memory: perform a rolling restart of all"
-warn "Keycloak nodes OR call POST /admin/realms/$TENANT/clear-realm-cache before"
-warn "actively managing the repaired roles."
+log "Intermediate CSVs left in $WORK_DIR for diagnosis — safe to delete."
+warn "Keycloak caches authorization data in memory: rolling-restart all Keycloak nodes OR call"
+warn "POST /admin/realms/$TENANT/clear-realm-cache before actively managing the repaired roles."
+if [[ "$KC_LEFTOVER" != "0" ]]; then
+    warn "INCOMPLETE: $KC_LEFTOVER Keycloak name(s)/description(s) still embed an id that resolves to no live role or user (a target absent from the maps — e.g. a user with permissions but no policy). A folio user id can be rebuilt from FOLIO on a re-run; a role id cannot, because its old→new mapping existed only while the two sides disagreed. Investigate before clearing caches."
+    exit 3
+fi
+log "Repair complete for tenant $TENANT. Re-run to verify: it must report 'Nothing to repair'."


### PR DESCRIPTION
## Purpose

After a same-cluster Keycloak realm migration, roles and authorization policies are assigned new UUIDs. `mod-roles-keycloak` stores both `role.id` and `policy.id` referencing those Keycloak UUIDs; when they go stale, roles become un-editable and Keycloak returns 404. The existing `repair-policy-uuids.sh` only fixes policy UUIDs. This PR adds `repair-role-policy-uuids.sh`, which repairs both in one operation — roles and policies must be fixed together because a role's UUID is embedded in its policy's name on both sides.

https://folio-org.atlassian.net/browse/KEYCLOAK-125

## Approach

- Added `keycloak-scripts/repair-role-policy-uuids.sh`: exports current role/policy UUIDs from Keycloak, builds an old→new map keyed by name, then runs a single FOLIO transaction that updates `role.id` and `policy.id` and all FK-dependent tables (`user_role`, `role_capability`, `role_capability_set`, `role_loadable`, `role_loadable_permission`, `policy_roles`, `policy_users`) and rewrites stale role-UUID references in `policy.name`/`policy.description`.
- After the FOLIO commit, rewrites the stale IDs from Keycloak's `resource_server_policy.name` and `policy_config.value` (looping until no rows match, since a single `UPDATE … FROM` applies at most one map row per target row).
- Pre-flight checks: schema drift guard (aborts if any affected table's columns differ from what the script's reinsert lists expect), duplicate name detection, and FOLIO-only role detection (`FORCE=true` to skip rather than abort).
- Supports `DRY_RUN=true` (runs and rolls back the FOLIO transaction, skips Keycloak entirely), a persisted role-id-map CSV for manual Keycloak recovery if the script fails between the two database commits, and re-runnable verification (a clean repair reports "Nothing to do").
- Updated `README.md` with a dedicated section covering environment variables, dry-run usage, recovery procedure for a half-finished run, and Keycloak cache-invalidation instructions. Reformatted several long lines in existing doc sections.

## TODOS and Open Questions

- [ ] Check logging

## Learning

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.